### PR TITLE
Using precision digits to round computed values

### DIFF
--- a/cvpack/atomic_function.py
+++ b/cvpack/atomic_function.py
@@ -108,10 +108,10 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
         >>> context.setPositions(model.positions)
         >>> theta1 = angle1.getValue(context).value_in_unit(openmm.unit.radian)
         >>> theta2 = angle2.getValue(context).value_in_unit(openmm.unit.radian)
-        >>> print(round(500*((theta1 - np.pi/2)**2 + (theta2 - np.pi/3)**2), 6))
-        429.479028
+        >>> print(round(500*((theta1 - np.pi/2)**2 + (theta2 - np.pi/3)**2), 3))
+        429.479
         >>> print(colvar.getValue(context, digits=6))
-        429.479028 kJ/mol
+        429.479 kJ/mol
     """
 
     @mmunit.convert_quantities
@@ -328,11 +328,11 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
         ...    value = state.getPotentialEnergy().value_in_unit(unit.kilojoules_per_mole)
         ...    print(f"{name}: original={value:.6f}, copy={force.getValue(context, digits=6)}")
         ...    forces[name].setForceGroup(0)
-        HarmonicBondForce: original=2094.312483, copy=2094.312483 kJ/mol
-        HarmonicAngleForce: original=3239.795215, copy=3239.795215 kJ/mol
-        PeriodicTorsionForce: original=4226.051934, copy=4226.051934 kJ/mol
+        HarmonicBondForce: original=2094.312483, copy=2094.312 kJ/mol
+        HarmonicAngleForce: original=3239.795215, copy=3239.795 kJ/mol
+        PeriodicTorsionForce: original=4226.051934, copy=4226.052 kJ/mol
         CustomExternalForce: original=5.021558, copy=5.021558 kJ/mol
-        HelixTorsionContent: original=17.452849, copy=17.452849 dimensionless
+        HelixTorsionContent: original=17.452849, copy=17.45285 dimensionless
         """
         if isinstance(
             force,

--- a/cvpack/centroid_function.py
+++ b/cvpack/centroid_function.py
@@ -89,9 +89,9 @@ class CentroidFunction(openmm.CustomCentroidBondForce, AbstractCollectiveVariabl
         >>> context =openmm.Context(model.system, integrator, platform)
         >>> context.setPositions(model.positions)
         >>> print(rg.getValue(context, digits=6))
-        0.295143 nm
+        0.2951431 nm
         >>> print(colvar.getValue(context, digits=6))
-        0.295143 nm
+        0.2951431 nm
     """
 
     def __init__(  # pylint: disable=too-many-arguments

--- a/cvpack/cvpack.py
+++ b/cvpack/cvpack.py
@@ -17,7 +17,7 @@ from openmm import app as mmapp
 
 from cvpack import unit as mmunit
 
-from .unit import in_md_units
+from .unit import value_in_md_units
 
 
 class SerializableResidue(mmapp.topology.Residue):
@@ -162,7 +162,7 @@ class AbstractCollectiveVariable(openmm.Force):
                 The number of digits to round to
         """
         state = self._getSingleForceState(context, getEnergy=True)
-        value = in_md_units(state.getPotentialEnergy())
+        value = value_in_md_units(state.getPotentialEnergy())
         return mmunit.Quantity(round(value, digits) if digits else value, self.getUnit())
 
     def getEffectiveMass(
@@ -210,9 +210,9 @@ class AbstractCollectiveVariable(openmm.Force):
             30.946932 Da
         """
         state = self._getSingleForceState(context, getForces=True)
-        force_values = in_md_units(state.getForces(asNumpy=True))
+        force_values = value_in_md_units(state.getForces(asNumpy=True))
         mass_values = [
-            in_md_units(context.getSystem().getParticleMass(i))
+            value_in_md_units(context.getSystem().getParticleMass(i))
             for i in range(context.getSystem().getNumParticles())
         ]
         effective_mass = 1.0 / np.sum(np.sum(force_values**2, axis=1) / mass_values)

--- a/cvpack/cvpack.py
+++ b/cvpack/cvpack.py
@@ -105,7 +105,7 @@ class AbstractCollectiveVariable(openmm.Force):
         context.reinitialize(preserveState=True)
         return state
 
-    def _precision_round(self, number: float, digits: Optional[int] = None) -> float:
+    def _precisionRound(self, number: float, digits: Optional[int] = None) -> float:
         """
         Round a number to a specified number of precision digits (if specified).
 
@@ -125,7 +125,7 @@ class AbstractCollectiveVariable(openmm.Force):
         """
         if digits is None:
             return number
-        power = "{:e}".format(number).split('e')[1]
+        power = f"{number:e}".split("e")[1]
         return round(number, -(int(power) - digits))
 
     @classmethod
@@ -193,7 +193,7 @@ class AbstractCollectiveVariable(openmm.Force):
         """
         state = self._getSingleForceState(context, getEnergy=True)
         value = value_in_md_units(state.getPotentialEnergy())
-        return mmunit.Quantity(self._precision_round(value, digits), self.getUnit())
+        return mmunit.Quantity(self._precisionRound(value, digits), self.getUnit())
 
     def getEffectiveMass(
         self, context: openmm.Context, digits: Optional[int] = None
@@ -249,4 +249,4 @@ class AbstractCollectiveVariable(openmm.Force):
         ]
         effective_mass = 1.0 / np.sum(np.sum(force_values**2, axis=1) / mass_values)
         unit = mmunit.dalton * (mmunit.nanometers / self.getUnit()) ** 2
-        return mmunit.Quantity(self._precision_round(effective_mass, digits), unit)
+        return mmunit.Quantity(self._precisionRound(effective_mass, digits), unit)

--- a/cvpack/helix_torsion_content.py
+++ b/cvpack/helix_torsion_content.py
@@ -95,7 +95,7 @@ class HelixTorsionContent(openmm.CustomTorsionForce, AbstractCollectiveVariable)
         >>> context = openmm.Context(model.system, integrator, platform)
         >>> context.setPositions(model.positions)
         >>> print(helix_content.getValue(context, digits=6))
-        17.452849 dimensionless
+        17.45285 dimensionless
     """
 
     @mmunit.convert_quantities

--- a/cvpack/radius_of_gyration.py
+++ b/cvpack/radius_of_gyration.py
@@ -65,7 +65,7 @@ class RadiusOfGyration(openmm.CustomCentroidBondForce, AbstractCollectiveVariabl
         >>> context =openmm.Context(model.system, integrator, platform)
         >>> context.setPositions(model.positions)
         >>> print(radius_of_gyration.getValue(context, digits=6))
-        0.295143 nm
+        0.2951431 nm
 
     """
 

--- a/cvpack/torsion_similarity.py
+++ b/cvpack/torsion_similarity.py
@@ -66,7 +66,7 @@ class TorsionSimilarity(openmm.CustomCompoundBondForce, AbstractCollectiveVariab
         >>> context =openmm.Context(model.system, integrator, platform)
         >>> context.setPositions(model.positions)
         >>> print(torsion_similarity.getValue(context, digits=6))
-        18.659917 dimensionless
+        18.65992 dimensionless
     """
 
     def __init__(


### PR DESCRIPTION
## Description
Collective variable values and effective masses can now optionally be rounded to a specified number of precision digits, which is the number of digits after the decimal point of the value in **scientific notation**.