### PR TITLE
Includes the RgSquared CV

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The CVs implemented in CVPack are:
     number of contacts between two groups of atoms
 * [Radius of gyration](https://cvpack.readthedocs.io/en/latest/api/RadiusOfGyration.html):
     radius of gyration of a group of atoms
+* [Radius of gyration squared](https://cvpack.readthedocs.io/en/latest/api/RadiusOfGyrationSquared.html):
+    square of the radius of gyration of a group of atoms
 * [RMSD](https://cvpack.readthedocs.io/en/latest/api/RMSD.html):
     root-mean-square deviation of atoms with respect to a reference structure
 * [Torsion](https://cvpack.readthedocs.io/en/latest/api/Torsion.html):

--- a/README.md
+++ b/README.md
@@ -31,38 +31,25 @@ to a [CustomCVForce] or used to define a [BiasVariable] for [Metadynamics], for 
 
 ### Collective Variables
 
-The CVs implemented in CVPack are:
+The CVs implemented in CVPack are listed in the table below.
 
-* [Angle](https://cvpack.readthedocs.io/en/latest/api/Angle.html):
-    angle formed by three atoms
-* [Atomic Function](https://cvpack.readthedocs.io/en/latest/api/AtomicFunction.html):
-    a user-defined function of the coordinates of a group of atoms
-* [Attraction Strength](https://cvpack.readthedocs.io/en/latest/api/AttractionStrength.html):
-    strength of the attraction between two groups of atoms
-* [Centroid Function](https://cvpack.readthedocs.io/en/latest/api/CentroidFunction.html):
-    a user-defined function of the centroids of groups of atoms
-* [Distance](https://cvpack.readthedocs.io/en/latest/api/Distance.html):
-    distance between two atoms
-* [Helix angle content](https://cvpack.readthedocs.io/en/latest/api/HelixAngleContent.html):
-    alpha-helix angle content of a sequence of residues
-* [Helix H-bond content](https://cvpack.readthedocs.io/en/latest/api/HelixHBondContent.html):
-    alpha-helix hydrogen-bond content of a sequence of residues
-* [Helix RMSD content](https://cvpack.readthedocs.io/en/latest/api/HelixRMSDContent.html):
-    alpha-helix RMSD content of a sequence of residues
-* [Helix torsion content](https://cvpack.readthedocs.io/en/latest/api/HelixTorsionContent.html):
-    alpha-helix Ramachandran content of a sequence of residues
-* [Number of contacts](https://cvpack.readthedocs.io/en/latest/api/NumberOfContacts.html):
-    number of contacts between two groups of atoms
-* [Radius of gyration](https://cvpack.readthedocs.io/en/latest/api/RadiusOfGyration.html):
-    radius of gyration of a group of atoms
-* [Radius of gyration squared](https://cvpack.readthedocs.io/en/latest/api/RadiusOfGyrationSquared.html):
-    square of the radius of gyration of a group of atoms
-* [RMSD](https://cvpack.readthedocs.io/en/latest/api/RMSD.html):
-    root-mean-square deviation of atoms with respect to a reference structure
-* [Torsion](https://cvpack.readthedocs.io/en/latest/api/Torsion.html):
-    torsion angle formed by four atoms
-* [Torsion similarity](https://cvpack.readthedocs.io/en/latest/api/TorsionSimilarity.html):
-    degree of similarity between pairs of torsion angles
+| Collective Variable     | Description                                                      |
+|-------------------------|------------------------------------------------------------------|
+| [Angle]                 | angle formed by three atoms                                      |
+| [Atomic Function]       | a user-defined function of the coordinates of a group of atoms   |
+| [Attraction Strength]   | strength of the attraction between two groups of atoms           |
+| [Centroid Function]     | a user-defined function of the centroids of groups of atoms      |
+| [Distance]              | distance between two atoms                                       |
+| [Helix angle content]   | alpha-helix angle content of a sequence of residues              |
+| [Helix H-bond content]  | alpha-helix hydrogen-bond content of a sequence of residues      |
+| [Helix RMSD content]    | alpha-helix RMSD content of a sequence of residues               |
+| [Helix torsion content] | alpha-helix Ramachandran content of a sequence of residues       |
+| [Number of contacts]    | number of contacts between two groups of atoms                   |
+| [Radius of gyration]    | radius of gyration of a group of atoms                           |
+| [Rg squared]            | square of the radius of gyration of a group of atoms             |
+| [RMSD]                  | root-mean-square deviation with respect to a reference structure |
+| [Torsion]               | torsion angle formed by four atoms                               |
+| [Torsion similarity]    | degree of similarity between pairs of torsion angles             |
 
 ### Installation and Usage
 
@@ -103,6 +90,22 @@ Project based on the [CMS Cookiecutter] version 1.1.
 [CollectiveVariable]: https://ufedmm.readthedocs.io/en/latest/pythonapi/ufedmm.html#ufedmm.ufedmm.CollectiveVariable
 [CustomCVForce]:      https://docs.openmm.org/latest/api-python/generated/openmm.openmm.CustomCVForce.html
 [Force]:              https://docs.openmm.org/latest/api-python/generated/openmm.openmm.Force.html
-[Metadynamics]:       https://docs.openmm.org/latest/api-python/generated/openmm.app.metadynamics.Metadynamics.
+[Metadynamics]:       https://docs.openmm.org/latest/api-python/generated/openmm.app.metadynamics.Metadynamics.html
 [OpenMM]:             https://openmm.org
 [UFED]:               https://ufedmm.readthedocs.io/en/latest/index.html
+
+[Angle]:                 https://cvpack.readthedocs.io/en/latest/api/Angle.html
+[Atomic Function]:       https://cvpack.readthedocs.io/en/latest/api/AtomicFunction.html
+[Attraction Strength]:   https://cvpack.readthedocs.io/en/latest/api/AttractionStrength.html
+[Centroid Function]:     https://cvpack.readthedocs.io/en/latest/api/CentroidFunction.html
+[Distance]:              https://cvpack.readthedocs.io/en/latest/api/Distance.html
+[Helix angle content]:   https://cvpack.readthedocs.io/en/latest/api/HelixAngleContent.html
+[Helix H-bond content]:  https://cvpack.readthedocs.io/en/latest/api/HelixHBondContent.html
+[Helix RMSD content]:    https://cvpack.readthedocs.io/en/latest/api/HelixRMSDContent.html
+[Helix torsion content]: https://cvpack.readthedocs.io/en/latest/api/HelixTorsionContent.html
+[Number of contacts]:    https://cvpack.readthedocs.io/en/latest/api/NumberOfContacts.html
+[Radius of gyration]:    https://cvpack.readthedocs.io/en/latest/api/RadiusOfGyration.html
+[Rg squared]:            https://cvpack.readthedocs.io/en/latest/api/RgSquared.html
+[RMSD]:                  https://cvpack.readthedocs.io/en/latest/api/RMSD.html
+[Torsion]:               https://cvpack.readthedocs.io/en/latest/api/Torsion.html
+[Torsion similarity]:    https://cvpack.readthedocs.io/en/latest/api/TorsionSimilarity.html

--- a/cvpack/__init__.py
+++ b/cvpack/__init__.py
@@ -13,6 +13,7 @@ from .helix_rmsd_content import HelixRMSDContent  # noqa: F401
 from .helix_torsion_content import HelixTorsionContent  # noqa: F401
 from .number_of_contacts import NumberOfContacts  # noqa: F401
 from .radius_of_gyration import RadiusOfGyration  # noqa: F401
+from .radius_of_gyration_squared import RadiusOfGyrationSquared  # noqa: F401
 from .rmsd import RMSD  # noqa: F401
 from .torsion import Torsion  # noqa: F401
 from .torsion_similarity import TorsionSimilarity  # noqa: F401

--- a/cvpack/radius_of_gyration.py
+++ b/cvpack/radius_of_gyration.py
@@ -41,6 +41,11 @@ class RadiusOfGyration(openmm.CustomCentroidBondForce, AbstractCollectiveVariabl
 
     where :math:`M = \\sum_{i=1}^n m_i` is the total mass of the group.
 
+    .. note::
+
+        This collective variable lacks parallelization and might be slow when the group of atoms
+        is large. In this case, :class:`RadiusOfGyrationSquared` might be preferred.
+
     Parameters
     ----------
         group

--- a/cvpack/radius_of_gyration_squared.py
+++ b/cvpack/radius_of_gyration_squared.py
@@ -2,7 +2,7 @@
 .. class:: RadiusOfGyrationSquared
    :platform: Linux, MacOS, Windows
 
-   :synopsis: The radius of gyration of a group of atoms
+   :synopsis: The square of the radius of gyration of a group of atoms
 
 .. classauthor:: Charlles Abreu <craabreu@gmail.com>
 
@@ -41,6 +41,11 @@ class RadiusOfGyrationSquared(openmm.CustomCentroidBondForce, AbstractCollective
         {\\bf r}_c({\\bf r}) = \\frac{1}{M} \\sum_{i=1}^n m_i {\\bf r}_i
 
     where :math:`M = \\sum_{i=1}^n m_i` is the total mass of the group.
+
+    .. note::
+
+        This collective variable is better parallelized than :class:`RadiusOfGyration` and might
+        be preferred over :class:`RadiusOfGyration` when the group of atoms is large.
 
     Parameters
     ----------

--- a/cvpack/radius_of_gyration_squared.py
+++ b/cvpack/radius_of_gyration_squared.py
@@ -1,6 +1,7 @@
 """
-.. class:: RadiusOfGyration
+.. class:: RadiusOfGyrationSquared
    :platform: Linux, MacOS, Windows
+
    :synopsis: The radius of gyration of a group of atoms
 
 .. classauthor:: Charlles Abreu <craabreu@gmail.com>
@@ -16,15 +17,15 @@ from cvpack import unit as mmunit
 from .cvpack import AbstractCollectiveVariable
 
 
-class RadiusOfGyration(openmm.CustomCentroidBondForce, AbstractCollectiveVariable):
+class RadiusOfGyrationSquared(openmm.CustomCentroidBondForce, AbstractCollectiveVariable):
     """
-    The radius of gyration of a group of :math:`n` atoms:
+    The square of the radius of gyration of a group of :math:`n` atoms:
 
     .. math::
 
-        r_g({\\bf r}) = \\sqrt{ \\frac{1}{n} \\sum_{i=1}^n \\left\\|
+        r_g^2({\\bf r}) = \\frac{1}{n} \\sum_{i=1}^n \\left\\|
             {\\bf r}_i - {\\bf r}_c({\\bf r})
-        \\right\\|^2 }.
+        \\right\\|^2.
 
     where :math:`{\\bf r}_c({\\bf r})` is the centroid of the group:
 
@@ -57,26 +58,25 @@ class RadiusOfGyration(openmm.CustomCentroidBondForce, AbstractCollectiveVariabl
         >>> from openmmtools import testsystems
         >>> model = testsystems.AlanineDipeptideVacuum()
         >>> num_atoms = model.system.getNumParticles()
-        >>> radius_of_gyration = cvpack.RadiusOfGyration(list(range(num_atoms)))
-        >>> model.system.addForce(radius_of_gyration)
+        >>> rgsq = cvpack.RadiusOfGyrationSquared(list(range(num_atoms)))
+        >>> model.system.addForce(rgsq)
         5
         >>> platform =openmm.Platform.getPlatformByName('Reference')
         >>> integrator =openmm.VerletIntegrator(0)
         >>> context =openmm.Context(model.system, integrator, platform)
         >>> context.setPositions(model.positions)
-        >>> print(radius_of_gyration.getValue(context, digits=6))
-        0.2951431 nm
+        >>> print(rgsq.getValue(context, digits=6))  # doctest: +ELLIPSIS
+        0.0871... nm**2
 
     """
 
     def __init__(self, group: Sequence[int], pbc: bool = False, weighByMass: bool = False) -> None:
         num_atoms = len(group)
-        num_groups = num_atoms + 1
-        sum_dist_sq = "+".join([f"distance(g{i+1}, g{num_atoms + 1})^2" for i in range(num_atoms)])
-        super().__init__(num_groups, f"sqrt(({sum_dist_sq})/{num_atoms})")
+        super().__init__(2, f"distance(g1, g2)^2/{num_atoms}")
         for atom in group:
             self.addGroup([atom], [1])
         self.addGroup(group, None if weighByMass else [1] * num_atoms)
-        self.addBond(list(range(num_groups)), [])
+        for atom in group:
+            self.addBond([atom, num_atoms])
         self.setUsesPeriodicBoundaryConditions(pbc)
-        self._registerCV(mmunit.nanometers, group, pbc, weighByMass)
+        self._registerCV(mmunit.nanometers**2, group, pbc, weighByMass)

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -199,6 +199,26 @@ def test_radius_of_gyration():
     perform_common_tests(rg_cv, context)
 
 
+def test_radius_of_gyration_squared():
+    """
+    Test whether a squared radius of gyration is computed correctly.
+
+    """
+    model = testsystems.AlanineDipeptideVacuum()
+    positions = model.positions.value_in_unit(unit.nanometers)
+    centroid = positions.mean(axis=0)
+    rgsq = np.sum((positions - centroid) ** 2) / model.system.getNumParticles()
+    rg_sq = cvpack.RadiusOfGyrationSquared(range(model.system.getNumParticles()))
+    model.system.addForce(rg_sq)
+    integrator = openmm.CustomIntegrator(0)
+    platform = openmm.Platform.getPlatformByName("Reference")
+    context = openmm.Context(model.system, integrator, platform)
+    context.setPositions(model.positions)
+    rg_sq_value = rg_sq.getValue(context).value_in_unit(unit.nanometers**2)
+    assert rg_sq_value == pytest.approx(rgsq)
+    perform_common_tests(rg_sq, context)
+
+
 def test_number_of_contacts():
     """
     Test whether a number of contacts is computed correctly.


### PR DESCRIPTION
## Description

The square of the radius of gyration is included as a more efficient alternative to RadiusOfGyration for large groups of atoms.