### PR TITLE
Adds new keyword argument to AttractionStrength

### DIFF
--- a/cvpack/attraction_strength.py
+++ b/cvpack/attraction_strength.py
@@ -140,7 +140,8 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
         cutoff = mmunit.value_in_md_units(nonbondedForce.getCutoffDistance())
         ref = 1 if reference is None else mmunit.value_in_md_units(reference)
         super().__init__(
-            f"{4 / ref}*epsilon*(1/y - 1/y^2) + {ONE_4PI_EPS0 / ref}*q12sq*(1/x + (x^2 - 3)/2)"
+            f"{4 / ref}*epsilon*(1/y - 1/y^2)"
+            f" + {ONE_4PI_EPS0 / ref}*q12sq*(1/x + (x^2 - 3)/2)"
             f"; x = r/{cutoff}"
             "; y = abs((r/sigma)^6 - 2) + 2"
             "; q12sq = max(0, -charge1*charge2)"

--- a/cvpack/attraction_strength.py
+++ b/cvpack/attraction_strength.py
@@ -7,7 +7,7 @@
 
 """
 
-from typing import Dict, Sequence
+import typing as t
 
 import openmm
 import xmltodict
@@ -16,12 +16,14 @@ from cvpack import unit as mmunit
 
 from .cvpack import AbstractCollectiveVariable
 
+ONE_4PI_EPS0 = 138.93545764438198
+
 
 class _NonbondedForce(openmm.NonbondedForce):
-    def __getstate__(self) -> Dict[str, str]:
+    def __getstate__(self) -> t.Dict[str, str]:
         return xmltodict.parse(openmm.XmlSerializer.serialize(self))
 
-    def __setstate__(self, state: Dict[str, str]) -> None:
+    def __setstate__(self, state: t.Dict[str, str]) -> None:
         self.__init__(openmm.XmlSerializer.deserialize(xmltodict.unparse(state)))
 
 
@@ -90,9 +92,14 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
     nonbondedForce
         The :openmm:`NonbondedForce` object from which to collect the necessary
         parameters.
+    reference
+        A reference value (in energy units per mole) to which the collective variable
+        should be normalized. If provided, the collective variable will become
+        dimensionless.
 
     Examples
     --------
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> model = testsystems.HostGuestExplicit()
     >>> group1, group2 = [], []
@@ -106,6 +113,11 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
     ... )
     >>> model.system.addForce(attraction_strength)
     5
+    >>> normalized_attraction_strength = AttractionStrength(
+    ...     group1, group2, forces["NonbondedForce"], 100*unit.kilojoules_per_mole,
+    ... )
+    >>> model.system.addForce(normalized_attraction_strength)
+    6
     >>> platform = openmm.Platform.getPlatformByName("Reference")
     >>> integrator = openmm.VerletIntegrator(1.0 * mmunit.femtoseconds)
     >>> context = openmm.Context(model.system, integrator, platform)
@@ -114,18 +126,21 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
     4912.514 kJ/mol
     >>> print(attraction_strength.getEffectiveMass(context, 6))
     2.163946e-07 nm**2 mol**2 Da/(kJ**2)
+    >>> print(normalized_attraction_strength.getValue(context, 6))
+    49.12514 dimensionless
     """
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        group1: Sequence[int],
-        group2: Sequence[int],
+        group1: t.Sequence[int],
+        group2: t.Sequence[int],
         nonbondedForce: openmm.NonbondedForce,
+        reference: t.Optional[mmunit.Quantity] = None,
     ) -> None:
-        one_4pi_eps0 = 138.93545764438198
         cutoff = mmunit.value_in_md_units(nonbondedForce.getCutoffDistance())
+        ref = 1 if reference is None else mmunit.value_in_md_units(reference)
         super().__init__(
-            f"4*epsilon*(1/y - 1/y^2) + {one_4pi_eps0}*q12sq*(1/x + (x^2 - 3)/2)"
+            f"{4 / ref}*epsilon*(1/y - 1/y^2) + {ONE_4PI_EPS0 / ref}*q12sq*(1/x + (x^2 - 3)/2)"
             f"; x = r/{cutoff}"
             "; y = abs((r/sigma)^6 - 2) + 2"
             "; q12sq = max(0, -charge1*charge2)"
@@ -146,8 +161,9 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
         self.setUseLongRangeCorrection(False)
         self.addInteractionGroup(group1, group2)
         self._registerCV(
-            mmunit.kilojoules_per_mole,
+            mmunit.kilojoules_per_mole if reference is None else mmunit.dimensionless,
             group1,
             group2,
             _NonbondedForce(nonbondedForce),
+            None if reference is None else mmunit.SerializableQuantity(reference),
         )


### PR DESCRIPTION
## Description

Includes the option of normalizing the attraction strength collective variable with respect to a provided reference value. In this case, such a collective variable becomes dimensionless.
