### PR TITLE
Changes step function definition in helix RMSD content cv

### DIFF
--- a/cvpack/helix_rmsd_content.py
+++ b/cvpack/helix_rmsd_content.py
@@ -26,51 +26,55 @@ class HelixRMSDContent(openmm.CustomCVForce, AbstractCollectiveVariable):
 
     .. math::
 
-        \\alpha_{\\rm rmsd}({\\bf r}) = \\sum_{i=1}^{n-5} B_m\\left(
+        \\alpha_{\\rm rmsd}({\\bf r}) = \\sum_{i=1}^{n-5} S\\left(
+            \\frac{r_{\\rm rmsd}({\\bf g}_i, {\\bf g}_{\\rm ref})}{r_0}
+        \\right)
+
+    where :math:`{\\bf g}_i` represents a group of atoms selected from residues
+    :math:`i` to :math:`i+5` of the sequence, :math:`{\\bf g}_{\\rm ref}` represents
+    the same atoms in an ideal alpha-helix configuration,
+    :math:`r_{\\rm rmsd}({\\bf g}_i, {\\bf g}_{\\rm ref})` is the root-mean-square
+    distance (RMSD) between :math:`{\\bf g}_i` and :math:`{\\bf g}_{\\rm ref}`,
+    :math:`r_0` is a threshold RMSD value, and :math:`S(x)` is a smooth step function
+    whose default form is
+
+    .. math::
+        S(x) = \\frac{1 + x^4}{1 + x^4 + x^8}
+
+    Each group :math:`{\\bf g}_i` is formed by the N, :math:`{\\rm C}_\\alpha`,
+    :math:`{\\rm C}_\\beta`, C, and O atoms of consecutive residues from :math:`i`
+    to :math:`i+5`, thus comprising a total of 30 atoms.  In the case glycine, the
+    missing :math:`{\\rm C}_\\beta` is replaced by the corresponding H atom. The
+    root-mean-square distance is then defined as
+
+    .. math::
+
+        r_{\\rm rmsd}({\\bf g}_i, {\\bf g}_{\\rm ref}) =
             \\sqrt{\\frac{1}{30} \\sum_{j=1}^{30} \\left\\|
                 \\hat{\\bf r}_j({\\bf g}_i) -
                 {\\bf A}({\\bf g}_i)\\hat{\\bf r}_j({\\bf g}_{\\rm ref})
             \\right\\|^2}
-        \\right)
 
-    where :math:`{\\bf g}_i` represents a group of 30 atoms selected from residues
-    :math:`i` to :math:`i+5` of the sequence, :math:`{\\bf g}_{\\rm ref}` represents the
-    same 30 atoms in an ideal alpha-helix configuration,
-    :math:`\\hat{\\bf r}_j({\\bf g})` is the position of the :math:`j`-th atom in a
-    group :math:`{\\bf g}` relative to the group's center of geometry (centroid),
+    where :math:`\\hat{\\bf r}_j({\\bf g})` is the position of the :math:`j`-th atom in
+    a group :math:`{\\bf g}` relative to the group's center of geometry (centroid),
     :math:`{\\bf A}({\\bf g})` is the rotation matrix that minimizes the RMSD between
-    :math:`{\\bf g}` and :math:`{\\bf g}_{\\rm ref}`, and :math:`B_m(x)` is a smooth
-    step function given by
+    :math:`{\\bf g}` and :math:`{\\bf g}_{\\rm ref}`.
 
-    .. math::
-        B_m(x) = \\frac{1}{1 + x^{2m}}
+    Optionally, alpha-helix RMSD content can be normalized to the range :math:`[0, 1]`.
 
-    where :math:`m` is an integer parameter that controls its steepness.
-
-    Each group :math:`{\\bf g}_i` is formed by the N, :math:`{\\rm C}_\\alpha`, C, and
-    O atoms of the backbone, as well as the :math:`{\\rm C}_\\beta` atoms of the six
-    consecutive residues starting from residue :math:`i`. In the case of glycine, the
-    missing :math:`{\\rm C}_\\beta` is replaced by the corresponding H atom.
+    This collective variable was introduced in Ref. :cite:`Pietrucci_2009`. The default
+    step function shown above is identical to the one in the original paper, but written
+    in a numerically safe form. The ideal alpha-helix configuration is the same used for
+    the collective variable `ALPHARMSD`_ in `PLUMED v2.8.1
+    <https://github.com/plumed/plumed2>`_ .
 
     .. note::
 
-        The residues must be a contiguous sequence from a single chain, ordered from the
-        N- to the C-terminus. The maximum supported number of residues is 1024.
-
-    This collective variable was introduced in Ref. :cite:`Pietrucci_2009` with a
-    slightly different step function. The ideal alpha-helix configuration is the same
-    used in `PLUMED v2.8.1 <https://github.com/plumed/plumed2>`_ for its collective
-    variable `ALPHARMSD`_. By setting :math:`{\\rm NN}=2m` and :math:`{\\rm MM}=4m`,
-    PLUMED's ALPHARMSD will match the collective variable implemented here.
-
-    Optionally, this collective variable can be normalized to the range :math:`[0, 1]`.
+        The residues must be a contiguous sequence from a single chain, ordered from
+        the N-terminus to the C-terminus. The minimum and maximum numbers of residues
+        supported in this implementation are 6 and 1029, respectively.
 
     .. _ALPHARMSD: https://www.plumed.org/doc-v2.8/user-doc/html/_a_l_p_h_a_r_m_s_d.html
-
-    .. warning::
-
-        Periodic boundary conditions are `not supported
-        <https://github.com/openmm/openmm/issues/2913>`_.
 
     Parameters
     ----------
@@ -79,9 +83,10 @@ class HelixRMSDContent(openmm.CustomCVForce, AbstractCollectiveVariable):
         numAtoms
             The total number of atoms in the system (required by OpenMM).
         thresholdRMSD
-            The threshold RMSD value for the step function.
-        halfExponent
-            The parameter :math:`m` of the step function.
+            The threshold RMSD value for considering a group of residues as matching an
+            alpha-helix.
+        stepFunction
+            The form of the step function :math:`S(x)`.
         normalize
             Whether to normalize the collective variable to the range :math:`[0, 1]`.
 
@@ -108,8 +113,8 @@ class HelixRMSDContent(openmm.CustomCVForce, AbstractCollectiveVariable):
         >>> integrator = openmm.VerletIntegrator(0)
         >>> context = openmm.Context(model.system, integrator, platform)
         >>> context.setPositions(model.positions)
-        >>> print(helix_content.getValue(context, digits=7))
-        15.915198 dimensionless
+        >>> print(helix_content.getValue(context, digits=4))
+        15.981 dimensionless
     """
 
     _ideal_helix_positions = 0.1 * np.loadtxt(
@@ -125,7 +130,7 @@ class HelixRMSDContent(openmm.CustomCVForce, AbstractCollectiveVariable):
         residues: t.Sequence[mmapp.topology.Residue],
         numAtoms: int,
         thresholdRMSD: mmunit.ScalarQuantity = mmunit.Quantity(0.08, mmunit.nanometers),
-        halfExponent: int = 3,
+        stepFunction: str = "(1+x^4)/(1+x^4+x^8)",
         normalize: bool = False,
     ) -> None:
         assert (
@@ -136,17 +141,19 @@ class HelixRMSDContent(openmm.CustomCVForce, AbstractCollectiveVariable):
         positions = [openmm.Vec3(*x) for x in self._ideal_helix_positions]
 
         def expression(start, end):
-            return "+".join(
-                f"1/(1+(rmsd{i+1}/{thresholdRMSD})^{2*halfExponent})"
-                for i in range(start, min(end, num_residue_blocks))
-            )
+            summands = []
+            definitions = []
+            for i in range(start, min(end, num_residue_blocks)):
+                summands.append(stepFunction.replace("x", f"x{i}"))
+                definitions.append(f"x{i}=rmsd{i}/{thresholdRMSD}")
+            return ";".join(["+".join(summands)] + definitions)
 
         if num_residue_blocks <= 32:
             summation = expression(0, num_residue_blocks)
             force = self
         else:
             summation = "+".join(
-                f"chunk{i+1}" for i in range((num_residue_blocks + 31) // 32)
+                f"chunk{i}" for i in range((num_residue_blocks + 31) // 32)
             )
         super().__init__(
             f"({summation})/{num_residue_blocks}" if normalize else summation
@@ -154,9 +161,9 @@ class HelixRMSDContent(openmm.CustomCVForce, AbstractCollectiveVariable):
         for index in range(num_residue_blocks):
             if num_residue_blocks > 32 and index % 32 == 0:
                 force = openmm.CustomCVForce(expression(index, index + 32))
-                self.addCollectiveVariable(f"chunk{index//32+1}", force)
+                self.addCollectiveVariable(f"chunk{index//32}", force)
             force.addCollectiveVariable(
-                f"rmsd{index+1}",
+                f"rmsd{index}",
                 RMSD(positions, sum(atoms[index : index + 6], []), numAtoms),
             )
 
@@ -165,7 +172,7 @@ class HelixRMSDContent(openmm.CustomCVForce, AbstractCollectiveVariable):
             list(map(SerializableResidue, residues)),
             numAtoms,
             thresholdRMSD,
-            halfExponent,
+            stepFunction,
             normalize,
         )
 

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -476,9 +476,8 @@ def test_helix_rmsd_content():
         for i in range(len(atoms) // 5 - 5):
             group = atoms[5 * i : 5 * i + 30]
             ref.xyz[:, group, :] = positions
-            computed_value += 1 / (
-                1 + (mdtraj.rmsd(traj, ref, 0, group).item() / 0.08) ** 6
-            )
+            x4 = (mdtraj.rmsd(traj, ref, 0, group).item() / 0.08) ** 4
+            computed_value += (1 + x4) / (1 + x4 + x4**2)
         return computed_value
 
     def select_atoms(stard, end):


### PR DESCRIPTION
## Description

This PR alters the way a step function is defined in the `HelixRMSDContent` CV and the default step function.

## Warning

This introduces a change of API, which is not backward compatible.