### PR TITLE
Allows AttractionStrength extract reference value from a context

### DIFF
--- a/cvpack/attraction_strength.py
+++ b/cvpack/attraction_strength.py
@@ -10,7 +10,6 @@
 import typing as t
 
 import openmm
-import xmltodict
 
 from cvpack import unit as mmunit
 
@@ -19,7 +18,9 @@ from .cvpack import AbstractCollectiveVariable
 ONE_4PI_EPS0 = 138.93545764438198
 
 
-class _NonbondedForceSurrogate:
+class _NonbondedForceSurrogate:  # pylint: disable=too-many-instance-attributes
+    """A surrogate class for the NonbondedForce class in OpenMM."""
+
     def __init__(self, other: openmm.NonbondedForce) -> None:
         self._cutoff = other.getCutoffDistance()
         self._uses_pbc = other.usesPeriodicBoundaryConditions()
@@ -61,30 +62,38 @@ class _NonbondedForceSurrogate:
         self._switching_distance = state["switching_distance"]
 
     def getCutoffDistance(self) -> float:
+        """Get the cutoff distance."""
         return mmunit.value_in_md_units(self._cutoff)
 
     def usesPeriodicBoundaryConditions(self) -> bool:
+        """Return whether periodic boundary conditions are used."""
         return self._uses_pbc
 
     def getNumParticles(self) -> int:
+        """Get the number of particles."""
         return self._num_particles
 
     def getParticleParameters(self, index: int) -> t.Tuple[float, float, float]:
+        """Get the parameters of a particle at the given index."""
         return tuple(map(mmunit.value_in_md_units, self._particle_parameters[index]))
 
     def getNumExceptions(self):
+        """Get the number of exceptions."""
         return self._num_exceptions
 
     def getExceptionParameters(
         self, index: int
     ) -> t.Tuple[int, int, float, float, float]:
+        """Get the parameters of an exception at the given index."""
         i, j, *params = self._exception_parameters[index]
         return i, j, *map(mmunit.value_in_md_units, params)
 
     def getUseSwitchingFunction(self) -> bool:
+        """Return whether a switching function is used."""
         return self._use_switching_function
 
     def getSwitchingDistance(self) -> float:
+        """Get the switching distance."""
         return mmunit.value_in_md_units(self._switching_distance)
 
 

--- a/cvpack/attraction_strength.py
+++ b/cvpack/attraction_strength.py
@@ -7,8 +7,8 @@
 
 """
 
-import typing as t
 import numbers
+import typing as t
 
 import openmm
 import xmltodict
@@ -181,7 +181,7 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
         self.setUseLongRangeCorrection(False)
         self.addInteractionGroup(group1, group2)
         if isinstance(reference, openmm.Context):
-            reference = self._get_value(reference)
+            reference = self._getValue(reference)
         if isinstance(reference, numbers.Number):
             self.setEnergyFunction(
                 expression.replace("refval = 1", f"refval = {reference}")
@@ -194,7 +194,7 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
             reference,
         )
 
-    def _get_value(self, context: openmm.Context) -> float:
+    def _getValue(self, context: openmm.Context) -> float:
         system = openmm.System()
         for _ in range(context.getSystem().getNumParticles()):
             system.addParticle(1.0)
@@ -203,5 +203,7 @@ class AttractionStrength(openmm.CustomNonbondedForce, AbstractCollectiveVariable
         context = openmm.Context(system, openmm.VerletIntegrator(1.0))
         context.setPositions(state.getPositions())
         context.setPeriodicBoxVectors(*state.getPeriodicBoxVectors())
+        # pylint: disable=unexpected-keyword-arg # to avoid false positive
         state = context.getState(getEnergy=True)
+        # pylint: enable=unexpected-keyword-arg
         return mmunit.value_in_md_units(state.getPotentialEnergy())


### PR DESCRIPTION
## Description

In addition to passing a numerical value, users can now pass a context to the `AttractionStrength` CV to define a reference value for normalization.