### PR TITLE
Improves AtomicFunction and CentroidFunction CV (breaks API)

### DIFF
--- a/cvpack/atomic_function.py
+++ b/cvpack/atomic_function.py
@@ -114,8 +114,8 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
         >>> angle2 = cvpack.Angle(10, 15, 20)
         >>> colvar = cvpack.AtomicFunction(
         ...     "(k/2)*(angle(p1, p2, p3) - theta0)^2",
-        ...     [[0, 5, 10], [10, 15, 20]],
         ...     unit.kilojoules_per_mole,
+        ...     [[0, 5, 10], [10, 15, 20]],
         ...     k = 1000 * unit.kilojoules_per_mole/unit.radian**2,
         ...     theta0 = [np.pi/2, np.pi/3] * unit.radian,
         ... )
@@ -136,8 +136,8 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
     def __init__(  # pylint: disable=too-many-arguments
         self,
         function: str,
-        groups: ArrayLike,
         unit: mmunit.Unit,
+        groups: ArrayLike,
         pbc: bool = False,
         **parameters: t.Union[mmunit.ScalarQuantity, t.Sequence[mmunit.ScalarQuantity]],
     ) -> None:
@@ -152,7 +152,7 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
         self.setUsesPeriodicBoundaryConditions(pbc)
         self._checkUnitCompatibility(unit)
         unit = mmunit.SerializableUnit(unit)
-        self._registerCV(unit, function, groups, unit, pbc, **parameters)
+        self._registerCV(unit, function, unit, groups, pbc, **parameters)
 
     @classmethod
     def _fromCustomForce(
@@ -208,7 +208,7 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
             for name, value in zip(per_item_parameter_names, per_item_parameters):
                 parameters[name].append(value)
         atoms = np.asarray(atoms).reshape(-1, number)
-        return cls(function, atoms, unit, pbc, **parameters)
+        return cls(function, unit, atoms, pbc, **parameters)
 
     @classmethod
     def _fromHarmonicBondForce(
@@ -227,7 +227,7 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
             atoms.append(indices)
             parameters["r0"].append(length)
             parameters["k"].append(k)
-        return cls("(k/2)*(distance(p1, p2)-r0)^2", atoms, unit, pbc, **parameters)
+        return cls("(k/2)*(distance(p1, p2)-r0)^2", unit, atoms, pbc, **parameters)
 
     @classmethod
     def _fromHarmonicAngleForce(
@@ -246,7 +246,7 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
             atoms.append(indices)
             parameters["theta0"].append(angle)
             parameters["k"].append(k)
-        return cls("(k/2)*(angle(p1, p2, p3)-theta0)^2", atoms, unit, pbc, **parameters)
+        return cls("(k/2)*(angle(p1, p2, p3)-theta0)^2", unit, atoms, pbc, **parameters)
 
     @classmethod
     def _fromPeriodicTorsionForce(
@@ -268,8 +268,8 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
             parameters["k"].append(k)
         return cls(
             "k*(1 + cos(periodicity*dihedral(p1, p2, p3, p4) - phase))",
-            atoms,
             unit,
+            atoms,
             pbc,
             **parameters,
         )

--- a/cvpack/atomic_function.py
+++ b/cvpack/atomic_function.py
@@ -138,7 +138,7 @@ class AtomicFunction(openmm.CustomCompoundBondForce, AbstractCollectiveVariable)
         function: str,
         unit: mmunit.Unit,
         groups: ArrayLike,
-        pbc: bool = False,
+        pbc: bool = True,
         **parameters: t.Union[mmunit.ScalarQuantity, t.Sequence[mmunit.ScalarQuantity]],
     ) -> None:
         groups = np.atleast_2d(groups)

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -617,12 +617,8 @@ def test_atomic_function():
     assert (
         str(excinfo.value) == "Unit angstrom is not compatible with the MD unit system."
     )
-<<<<<<< HEAD
     colvar = cvpack.AtomicFunction(function, unit.nanometers, atoms)
-=======
-    colvar = cvpack.AtomicFunction(num_atoms, function, atoms, unit.nanometers)
     colvar.setUnusedForceGroup(0, model.system)
->>>>>>> main
     model.system.addForce(colvar)
     context = openmm.Context(
         model.system,
@@ -662,7 +658,6 @@ def test_centroid_function():
     colvar = cvpack.CentroidFunction(
         function, unit.nanometers, groups, weighByMass=False
     )
-    colvar.setUnusedForceGroup(0, model.system)
     colvar.setUnusedForceGroup(0, model.system)
     model.system.addForce(colvar)
     context = openmm.Context(

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -630,15 +630,14 @@ def test_centroid_function():
     np.random.shuffle(atoms)
     num_groups = num_atoms // 3
     groups = np.reshape(atoms[: 3 * num_groups], (num_groups, 3))
-    collection = list(range(num_groups))
     function = "+".join(f"distance(g{i+1}, g{i+2})" for i in range(num_groups - 1))
     with pytest.raises(ValueError) as excinfo:
-        colvar = cvpack.CentroidFunction(function, groups, collection, unit.angstrom)
+        colvar = cvpack.CentroidFunction(function, unit.angstrom, groups)
     assert (
         str(excinfo.value) == "Unit angstrom is not compatible with the MD unit system."
     )
     colvar = cvpack.CentroidFunction(
-        function, groups, collection, unit.nanometers, weighByMass=False
+        function, unit.nanometers, groups, weighByMass=False
     )
     model.system.addForce(colvar)
     context = openmm.Context(

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -595,11 +595,11 @@ def test_atomic_function():
     np.random.shuffle(atoms)
     function = "+".join(f"distance(p{i+1}, p{i+2})" for i in range(num_atoms - 1))
     with pytest.raises(ValueError) as excinfo:
-        colvar = cvpack.AtomicFunction(num_atoms, function, atoms, unit.angstrom)
+        colvar = cvpack.AtomicFunction(function, atoms, unit.angstrom)
     assert (
         str(excinfo.value) == "Unit angstrom is not compatible with the MD unit system."
     )
-    colvar = cvpack.AtomicFunction(num_atoms, function, atoms, unit.nanometers)
+    colvar = cvpack.AtomicFunction(function, atoms, unit.nanometers)
     model.system.addForce(colvar)
     context = openmm.Context(
         model.system,

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -630,14 +630,15 @@ def test_centroid_function():
     np.random.shuffle(atoms)
     num_groups = num_atoms // 3
     groups = np.reshape(atoms[: 3 * num_groups], (num_groups, 3))
+    collection = list(range(num_groups))
     function = "+".join(f"distance(g{i+1}, g{i+2})" for i in range(num_groups - 1))
     with pytest.raises(ValueError) as excinfo:
-        colvar = cvpack.CentroidFunction(function, groups, unit.angstrom)
+        colvar = cvpack.CentroidFunction(function, groups, collection, unit.angstrom)
     assert (
         str(excinfo.value) == "Unit angstrom is not compatible with the MD unit system."
     )
     colvar = cvpack.CentroidFunction(
-        function, groups, unit.nanometers, weighByMass=False
+        function, groups, collection, unit.nanometers, weighByMass=False
     )
     model.system.addForce(colvar)
     context = openmm.Context(

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -595,11 +595,11 @@ def test_atomic_function():
     np.random.shuffle(atoms)
     function = "+".join(f"distance(p{i+1}, p{i+2})" for i in range(num_atoms - 1))
     with pytest.raises(ValueError) as excinfo:
-        colvar = cvpack.AtomicFunction(function, atoms, unit.angstrom)
+        colvar = cvpack.AtomicFunction(function, unit.angstrom, atoms)
     assert (
         str(excinfo.value) == "Unit angstrom is not compatible with the MD unit system."
     )
-    colvar = cvpack.AtomicFunction(function, atoms, unit.nanometers)
+    colvar = cvpack.AtomicFunction(function, unit.nanometers, atoms)
     model.system.addForce(colvar)
     context = openmm.Context(
         model.system,


### PR DESCRIPTION
## Description

- Allows centroid functions to be defined as sums for multiple collections of atom groups.
- Changes `AtomicFunction` and `CentroidFunction` API for mutual compatibility.