### PR TITLE
Makes RMSD compatible with CompositeRMSD (breaks API)

### DIFF
--- a/cvpack/base_rmsd_content.py
+++ b/cvpack/base_rmsd_content.py
@@ -68,7 +68,12 @@ class BaseRMSDContent(openmm.CustomCVForce, BaseCollectiveVariable):
                 force = openmm.CustomCVForce(expression(index))
                 self.addCollectiveVariable(f"chunk{index//32}", force)
             force.addCollectiveVariable(
-                f"rmsd{index}", RMSD(ideal_positions, block_atoms[index], numAtoms)
+                f"rmsd{index}",
+                RMSD(
+                    dict(zip(block_atoms[index], ideal_positions)),
+                    block_atoms[index],
+                    numAtoms,
+                ),
             )
 
     @classmethod

--- a/cvpack/composite_rmsd.py
+++ b/cvpack/composite_rmsd.py
@@ -63,63 +63,66 @@ class CompositeRMSD(CompositeRMSDForce, BaseCollectiveVariable):
 
         To use this class, you must install the `openmm-cpp-forces`_ conda package.
 
-    .. _openmm-cpp-forces: https://anaconda.org/mdtools/openmm-cpp-forces
+    .. _openmm-cpp-forces:
+
+        https://anaconda.org/mdtools/openmm-cpp-forces
 
     Parameters
     ----------
-        referencePositions
-            The reference coordinates. It can be either a matrix or a dictionary whose
-            keys and values are atom indices and position vectors, respectively.
-        groups
-            A sequence of disjoint atom groups. Each group is a sequence of atom
-            indices.
-        numAtoms
-            The total number of atoms in the system, including those that are not in any
-            group. This argument is necessary only if ``referencePositions`` does not
-            contain all atoms in the system.
+    referencePositions
+        The reference coordinates, which can be either a coordinate matrix or a mapping
+        from atom indices to coordinate vectors. It must contain all atoms in
+        ``groups``, and does not need to contain all atoms in the system. See
+        ``numAtoms`` below.
+    groups
+        A sequence of disjoint atom groups. Each group is a sequence of atom indices.
+    numAtoms
+        The total number of atoms in the system, including those that are not in
+        ``groups``. This argument is necessary only if ``referencePositions`` does not
+        contain all atoms in the system.
 
     Raises
     ------
-        ImportError
-            If the `openmm-cpp-forces`_ conda package is not installed.
-        ValueError
-            If ``groups`` is not a sequence of disjoint atom groups.
+    ImportError
+        If the `openmm-cpp-forces`_ conda package is not installed.
+    ValueError
+        If ``groups`` is not a sequence of disjoint atom groups.
 
     Example
     -------
-        >>> import cvpack
-        >>> import openmm as mm
-        >>> import pytest
-        >>> from openmmtools import testsystems
-        >>> from cvpack import unit
-        >>> model = testsystems.HostGuestVacuum()
-        >>> host_atoms, guest_atoms = (
-        ...     [a.index for a in r.atoms()]
-        ...     for r in model.topology.residues()
-        ... )
-        >>> try:
-        ...     composite_rmsd = cvpack.CompositeRMSD(
-        ...         model.positions,
-        ...         [host_atoms, guest_atoms],
-        ...     )
-        ... except ImportError:
-        ...     pytest.skip("openmm-cpp-forces is not installed")
-        >>> composite_rmsd.setUnusedForceGroup(0, model.system)
-        1
-        >>> model.system.addForce(composite_rmsd)
-        5
-        >>> context = mm.Context(
-        ...     model.system,
-        ...     mm.VerletIntegrator(1.0 * unit.femtoseconds),
-        ...     mm.Platform.getPlatformByName('Reference'),
-        ... )
-        >>> context.setPositions(model.positions)
-        >>> print(composite_rmsd.getValue(context))
-        0.0 nm
-        >>> model.positions[guest_atoms] += 1.0 * unit.nanometers
-        >>> context.setPositions(model.positions)
-        >>> print(composite_rmsd.getValue(context))
-        0.0 nm
+    >>> import cvpack
+    >>> import openmm as mm
+    >>> import pytest
+    >>> from openmmtools import testsystems
+    >>> from cvpack import unit
+    >>> model = testsystems.HostGuestVacuum()
+    >>> host_atoms, guest_atoms = (
+    ...     [a.index for a in r.atoms()]
+    ...     for r in model.topology.residues()
+    ... )
+    >>> try:
+    ...     composite_rmsd = cvpack.CompositeRMSD(
+    ...         model.positions,
+    ...         [host_atoms, guest_atoms],
+    ...     )
+    ... except ImportError:
+    ...     pytest.skip("openmm-cpp-forces is not installed")
+    >>> composite_rmsd.setUnusedForceGroup(0, model.system)
+    1
+    >>> model.system.addForce(composite_rmsd)
+    5
+    >>> context = mm.Context(
+    ...     model.system,
+    ...     mm.VerletIntegrator(1.0 * unit.femtoseconds),
+    ...     mm.Platform.getPlatformByName('Reference'),
+    ... )
+    >>> context.setPositions(model.positions)
+    >>> print(composite_rmsd.getValue(context))
+    0.0 nm
+    >>> model.positions[guest_atoms] += 1.0 * unit.nanometers
+    >>> context.setPositions(model.positions)
+    >>> print(composite_rmsd.getValue(context))
+    0.0 nm
     """
 
     @mmunit.convert_quantities
@@ -138,7 +141,6 @@ class CompositeRMSD(CompositeRMSDForce, BaseCollectiveVariable):
         defined_coords = {atom: referencePositions[atom] for atom in all_atoms}
         all_coords = np.zeros((num_atoms, 3))
         for atom, coords in defined_coords.items():
-            # print(coords)
             all_coords[atom, :] = coords
         super().__init__(all_coords)
         for group in groups:

--- a/cvpack/rmsd.py
+++ b/cvpack/rmsd.py
@@ -7,7 +7,6 @@
 
 """
 
-import copy
 import typing as t
 
 import numpy as np
@@ -19,49 +18,46 @@ from .cvpack import BaseCollectiveVariable
 
 
 class RMSD(openmm.RMSDForce, BaseCollectiveVariable):
-    r"""
+    """
     The minimum root-mean-square deviation (RMSD) between the current and reference
     coordinates of a group of `n` atoms:
 
     .. math::
 
         d_{\rm rms}({\bf r}) = \sqrt{
-            \frac{1}{n} \sum_{i=1}^n \left\|
-                \hat{\bf r}_i - {\bf A}({\bf r}) \hat{\bf r}_i^{\rm ref}
+            \frac{1}{n} \min_{
+                \bf q \in \mathbb{R}^4 \atop \|{\bf q}\| = 1
+            } \sum_{i=1}^n \left\|
+                {\bf A}({\bf q}) \hat{\bf r}_i - \hat{\bf r}_i^{\rm ref}
             \right\|^2
         }
 
     where :math:`\hat{\bf r}_i` is the position of the :math:`i`-th atom in the group
-    relative to the group's center of geometry (centroid),
-    :math:`\hat{\bf r}_i^{\rm ref}` is the centroid-centered position of the same
-    atom in a reference configuration, and :math:`{\bf A}({\bf r})` is the rotation
-    matrix that minimizes the RMSD between the group and the reference structure.
+    relative to the group's center of geometry (centroid), the superscript
+    :math:`\rm ref` denotes the reference structure, :math:`{\bf q}` is a unit
+    quaternion, and :math:`{\bf A}({\bf q})` is the rotation matrix corresponding to
+    :math:`{\bf q}`.
 
     .. warning::
 
         Periodic boundary conditions are `not supported
-        <https://github.com/openmm/openmm/issues/2913>`_. It atoms in the group belong
-        to distinct molecules, calling :func:`getNullBondForce` and adding the resulting
-        force to the system might circumvent any potential issues.
+        <https://github.com/openmm/openmm/issues/2913>`_. This is not a problem if all
+        atoms in the group belong to the same molecule. If they belong to distinct
+        molecules, it is possible to circumvent the issue by calling the method
+        :func:`getNullBondForce` and adding the resulting force to the system.
 
     Parameters
     ----------
-        referencePositions
-            The reference coordinates. If there are ``n`` coordinates,  with
-            ``n=len(group)``, they must refer to the group atoms in the same order as
-            they appear in ``group``. Otherwise, if there are ``numAtoms`` coordinates
-            (see below), they must refer to the the system atoms and be sorted
-            accordingly. The first criterion has precedence over the second when
-            ``n == numAtoms``.
-        group
-            The index of the atoms in the group
-        numAtoms
-            The total number of atoms in the system (required by OpenMM)
-
-    Raises
-    ------
-        ValueError
-            If ``len(referencePositions)`` is neither ``numAtoms`` nor ``len(group)``
+    referencePositions
+        The reference coordinates, which can be either a coordinate matrix or a mapping
+        from atom indices to coordinate vectors. It must contain all atoms in ``group``,
+        and does not need to contain all atoms in the system. See ``numAtoms`` below.
+    groups
+        A sequence of atom indices.
+    numAtoms
+        The total number of atoms in the system, including those that are not in
+        ``group``. This argument is necessary only if ``referencePositions`` does not
+        contain all atoms in the system.
 
     Example
     -------
@@ -91,23 +87,19 @@ class RMSD(openmm.RMSDForce, BaseCollectiveVariable):
     @mmunit.convert_quantities
     def __init__(
         self,
-        referencePositions: mmunit.MatrixQuantity,
+        referencePositions: t.Union[
+            mmunit.MatrixQuantity, t.Dict[int, mmunit.VectorQuantity]
+        ],
         group: t.Sequence[int],
-        numAtoms: int,
+        numAtoms: t.Optional[int] = None,
     ) -> None:
-        coords = referencePositions
-        num_coords = coords.shape[0] if isinstance(coords, np.ndarray) else len(coords)
-        if num_coords == len(group):
-            positions = np.zeros((numAtoms, 3))
-            for i, atom in enumerate(group):
-                positions[atom, :] = np.array([coords[i][j] for j in range(3)])
-        elif num_coords == numAtoms:
-            positions = copy.deepcopy(coords)
-            coords = np.array([positions[atom] for atom in group])
-        else:
-            raise ValueError("Invalid number of coordinates")
-        super().__init__(positions, group)
-        self._registerCV(mmunit.nanometers, coords, group, numAtoms)
+        num_atoms = numAtoms or len(referencePositions)
+        defined_coords = {atom: referencePositions[atom] for atom in group}
+        all_coords = np.zeros((num_atoms, 3))
+        for atom, coords in defined_coords.items():
+            all_coords[atom, :] = coords
+        super().__init__(all_coords, group)
+        self._registerCV(mmunit.nanometers, defined_coords, group, num_atoms)
 
     def getNullBondForce(self) -> openmm.HarmonicBondForce:
         """
@@ -149,6 +141,6 @@ class RMSD(openmm.RMSDForce, BaseCollectiveVariable):
         """
         force = openmm.HarmonicBondForce()
         group = self._args["group"]
-        for i in range(len(group) - 1):
-            force.addBond(group[i], group[i + 1], 0.0, 0.0)
+        for i, j in zip(group[:-1], group[1:]):
+            force.addBond(i, j, 0.0, 0.0)
         return force

--- a/cvpack/rmsd.py
+++ b/cvpack/rmsd.py
@@ -18,7 +18,7 @@ from .cvpack import BaseCollectiveVariable
 
 
 class RMSD(openmm.RMSDForce, BaseCollectiveVariable):
-    """
+    r"""
     The minimum root-mean-square deviation (RMSD) between the current and reference
     coordinates of a group of `n` atoms:
 

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -312,7 +312,7 @@ def run_rmsd_test(
     if passVec3:
         reference = [openmm.Vec3(*row) for row in reference]
     rmsd = cvpack.RMSD(
-        group_ref if passGroupOnly else reference,
+        dict(zip(group, group_ref)) if passGroupOnly else reference,
         group,
         num_atoms,
     )


### PR DESCRIPTION
## Description

Requires a mapping (dictionary) from atom indices to coordinate vectors if the passed reference positions do not contain all atoms in the system.