### PR TITLE
Fixes issue with multiple custom functions

### DIFF
--- a/cvpack/base_custom_function.py
+++ b/cvpack/base_custom_function.py
@@ -45,8 +45,8 @@ class BaseCustomFunction(BaseCollectiveVariable):
         unit: t.Optional[mmunit.Unit] = None,
     ) -> None:
         # pylint: disable=no-member
-        for name, value in overalls.items():
-            self.addGlobalParameter(name, value)
+        definitions = "; ".join(f"{name}={value}" for name, value in overalls.items())
+        self.setEnergyFunction(f"{self.getEnergyFunction()}; {definitions}")
         for name in perbonds:
             self.addPerBondParameter(name)
         for group, *values in zip(groups, *perbonds.values()):


### PR DESCRIPTION
## Description

Global parameters are now hardcoded in `AtomicFunction` and `CentroidFunction` expressions to avoid ambiguity when using the same parameter names for multiple CVs.