### PR TITLE
Adds contrast-group option to AttractionStrength

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
 
 ignored-modules=openmm.unit
 ignore=_version.py
-extension-pkg-whitelist=rdkit,openmm.app.internal.compiled
+extension-pkg-whitelist=openmm.app.internal.compiled
 
 [DESIGN]
 


### PR DESCRIPTION
## Description

Allows the definition of a contrast group in the `AttractionStrength` CV, so that the computed value is the difference between `group1-group2` and `group1-contrastGroup` interactions