### PR TITLE
Automatically replace non-serializable objects at CV registry

### DIFF
--- a/cvpack/cvpack.py
+++ b/cvpack/cvpack.py
@@ -17,7 +17,7 @@ from openmm import unit as mmunit
 
 from .serialization import Serializable
 from .units import Quantity, ScalarQuantity, Unit, value_in_md_units
-from .utils import compute_effective_mass, get_single_force_state, preprocess_units
+from .utils import compute_effective_mass, get_single_force_state, preprocess_args
 
 
 class BaseCollectiveVariable(openmm.Force, Serializable):
@@ -42,7 +42,7 @@ class BaseCollectiveVariable(openmm.Force, Serializable):
     def __deepcopy__(self, memo):
         return yaml.safe_load(yaml.safe_dump(self))
 
-    @preprocess_units
+    @preprocess_args
     def _registerCV(
         self,
         name: str,
@@ -218,7 +218,6 @@ class BaseCollectiveVariable(openmm.Force, Serializable):
         -------
         unit.Quantity
             The value of this collective variable at the given context
-
 
         Example
         -------

--- a/cvpack/cvpack.py
+++ b/cvpack/cvpack.py
@@ -16,8 +16,8 @@ import yaml
 from openmm import unit as mmunit
 
 from .serialization import Serializable
-from .units import Quantity, ScalarQuantity, Unit, preprocess_units, value_in_md_units
-from .utils import compute_effective_mass, get_single_force_state
+from .units import Quantity, ScalarQuantity, Unit, value_in_md_units
+from .utils import compute_effective_mass, get_single_force_state, preprocess_units
 
 
 class BaseCollectiveVariable(openmm.Force, Serializable):

--- a/cvpack/helix_angle_content.py
+++ b/cvpack/helix_angle_content.py
@@ -14,7 +14,6 @@ from openmm import app as mmapp
 from openmm import unit as mmunit
 
 from .cvpack import BaseCollectiveVariable
-from .serialization import SerializableResidue
 from .units import ScalarQuantity
 
 
@@ -128,7 +127,6 @@ class HelixAngleContent(openmm.CustomAngleForce, BaseCollectiveVariable):
                 [],
             )
         self.setUsesPeriodicBoundaryConditions(pbc)
-        residues = list(map(SerializableResidue, residues))
         self._registerCV(
             name,
             None,

--- a/cvpack/helix_hbond_content.py
+++ b/cvpack/helix_hbond_content.py
@@ -15,7 +15,6 @@ from openmm import app as mmapp
 from openmm import unit as mmunit
 
 from .cvpack import BaseCollectiveVariable
-from .serialization import SerializableResidue
 from .units import ScalarQuantity
 
 
@@ -113,7 +112,6 @@ class HelixHBondContent(openmm.CustomBondForce, BaseCollectiveVariable):
                 [],
             )
         self.setUsesPeriodicBoundaryConditions(pbc)
-        residues = list(map(SerializableResidue, residues))
         self._registerCV(
             name, None, residues, pbc, thresholdDistance, halfExponent, normalize
         )

--- a/cvpack/helix_rmsd_content.py
+++ b/cvpack/helix_rmsd_content.py
@@ -13,7 +13,6 @@ from openmm import app as mmapp
 from openmm import unit as mmunit
 
 from .base_rmsd_content import BaseRMSDContent
-from .serialization import SerializableResidue
 from .units import ScalarQuantity
 
 # pylint: disable=protected-access
@@ -150,7 +149,6 @@ class HelixRMSDContent(BaseRMSDContent):
             stepFunction,
             normalize,
         )
-        residues = list(map(SerializableResidue, residues))
         self._registerCV(
             name, None, residues, numAtoms, thresholdRMSD, stepFunction, normalize
         )

--- a/cvpack/helix_torsion_content.py
+++ b/cvpack/helix_torsion_content.py
@@ -14,7 +14,6 @@ from openmm import app as mmapp
 from openmm import unit as mmunit
 
 from .cvpack import BaseCollectiveVariable
-from .serialization import SerializableResidue
 from .units import ScalarQuantity
 
 
@@ -145,7 +144,6 @@ class HelixTorsionContent(openmm.CustomTorsionForce, BaseCollectiveVariable):
                 [psiReference],
             )
         self.setUsesPeriodicBoundaryConditions(pbc)
-        residues = list(map(SerializableResidue, residues))
         self._registerCV(
             name,
             None,

--- a/cvpack/meta_collective_variable.py
+++ b/cvpack/meta_collective_variable.py
@@ -16,7 +16,7 @@ import openmm
 from openmm import unit as mmunit
 
 from .cvpack import BaseCollectiveVariable
-from .units import Quantity, ScalarQuantity, VectorQuantity, preprocess_units
+from .units import Quantity, ScalarQuantity, VectorQuantity
 from .utils import compute_effective_mass
 
 
@@ -92,7 +92,6 @@ class MetaCollectiveVariable(openmm.CustomCVForce, BaseCollectiveVariable):
     {'phi': 0.05119... nm**2 Da/(rad**2)}
     """
 
-    @preprocess_units
     def __init__(
         self,
         function: str,

--- a/cvpack/number_of_contacts.py
+++ b/cvpack/number_of_contacts.py
@@ -8,13 +8,14 @@
 """
 
 import typing as t
+from numbers import Real
 
 import openmm
 from openmm import unit as mmunit
 
 from .cvpack import BaseCollectiveVariable
 from .units import ScalarQuantity
-from .utils import NonbondedForceSurrogate, evaluate_in_context
+from .utils import evaluate_in_context
 
 
 class NumberOfContacts(openmm.CustomNonbondedForce, BaseCollectiveVariable):
@@ -127,19 +128,19 @@ class NumberOfContacts(openmm.CustomNonbondedForce, BaseCollectiveVariable):
         group1: t.Sequence[int],
         group2: t.Sequence[int],
         nonbondedForce: openmm.NonbondedForce,
-        reference: t.Union[ScalarQuantity, openmm.Context] = 1.0,
+        reference: t.Union[Real, openmm.Context] = 1.0,
         stepFunction: str = "1/(1+x^6)",
         thresholdDistance: ScalarQuantity = 0.3 * mmunit.nanometers,
         cutoffFactor: float = 2.0,
         switchFactor: t.Optional[float] = 1.5,
         name: str = "number_of_contacts",
     ) -> None:
-        nonbondedForce = NonbondedForceSurrogate(nonbondedForce)
+        # nonbondedForce = NonbondedForceSurrogate(nonbondedForce)
         num_atoms = nonbondedForce.getNumParticles()
         pbc = nonbondedForce.usesPeriodicBoundaryConditions()
         threshold = thresholdDistance
         if mmunit.is_quantity(threshold):
-            threshold = threshold.value_in_unit_system(mmunit.md_unit_system)
+            threshold = threshold.value_in_unit(mmunit.nanometers)
         expression = f"({stepFunction})/1; x=r/{threshold}"
         super().__init__(expression)
         nonbonded_method = self.CutoffPeriodic if pbc else self.CutoffNonPeriodic

--- a/cvpack/residue_coordination.py
+++ b/cvpack/residue_coordination.py
@@ -14,7 +14,6 @@ from openmm import unit as mmunit
 from openmm.app.topology import Residue
 
 from .cvpack import BaseCollectiveVariable
-from .serialization import SerializableResidue
 from .units import ScalarQuantity, value_in_md_units
 
 
@@ -117,8 +116,8 @@ class ResidueCoordination(openmm.CustomCentroidBondForce, BaseCollectiveVariable
         includeHydrogens: bool = True,
         name: str = "residue_coordination",
     ) -> None:
-        residueGroup1 = list(map(SerializableResidue, residueGroup1))
-        residueGroup2 = list(map(SerializableResidue, residueGroup2))
+        residueGroup1 = list(residueGroup1)
+        residueGroup2 = list(residueGroup2)
         nr1 = len(residueGroup1)
         nr2 = len(residueGroup2)
         self._ref_val = nr1 * nr2 if normalize else 1.0

--- a/cvpack/serialization/__init__.py
+++ b/cvpack/serialization/__init__.py
@@ -6,6 +6,7 @@ Serializer submodule of CVPack
 from .serialization import (  # noqa: F401
     Serializable,
     SerializableAtom,
+    SerializableForce,
     SerializableResidue,
     deserialize,
     serialize,

--- a/cvpack/sheet_rmsd_content.py
+++ b/cvpack/sheet_rmsd_content.py
@@ -14,7 +14,6 @@ from openmm import app as mmapp
 from openmm import unit as mmunit
 
 from .base_rmsd_content import BaseRMSDContent
-from .serialization import SerializableResidue
 from .units import ScalarQuantity
 
 # pylint: disable=protected-access
@@ -221,7 +220,7 @@ class SheetRMSDContent(BaseRMSDContent):
         self._registerCV(
             name,
             None,
-            list(map(SerializableResidue, residues)),
+            residues,
             numAtoms,
             parallel,
             blockSizes,

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -101,6 +101,8 @@ def perform_common_tests(
     mass1 = collectiveVariable.getEffectiveMass(context)
     mass2 = new_cv.getEffectiveMass(context)
     assert mass1 / mass1.unit == mass2 / mass2.unit
+    assert collectiveVariable.getName() == new_cv.getName()
+    assert collectiveVariable.getPeriodicBounds() == new_cv.getPeriodicBounds()
 
 
 def test_cv_is_in_context():

--- a/cvpack/units/__init__.py
+++ b/cvpack/units/__init__.py
@@ -9,6 +9,5 @@ from .units import (  # noqa: F401
     ScalarQuantity,
     Unit,
     VectorQuantity,
-    preprocess_units,
     value_in_md_units,
 )

--- a/cvpack/units/units.py
+++ b/cvpack/units/units.py
@@ -8,8 +8,6 @@
 """
 
 import ast
-import functools
-import inspect
 import typing as t
 from numbers import Real
 
@@ -104,61 +102,6 @@ class Quantity(mmunit.Quantity, Serializable):
 
 
 Quantity.registerTag("!cvpack.Quantity")
-
-
-def preprocess_units(func: t.Callable) -> t.Callable:
-    """
-    A decorator that converts instances of openmm.unit.Unit and openmm.unit.Quantity
-    into openxps.units.Unit and openxps.units.Quantity, respectively.
-
-    Parameters
-    ----------
-        func
-            The function to be decorated.
-
-    Returns
-    -------
-        The decorated function.
-
-    Example
-    -------
-    >>> from cvpack import units
-    >>> from openmm import unit as mmunit
-    >>> @units.preprocess_units
-    ... def function(data):
-    ...     return data
-    >>> assert isinstance(function(mmunit.angstrom), units.Unit)
-    >>> assert isinstance(function(5 * mmunit.angstrom), units.Quantity)
-    >>> seq = [mmunit.angstrom, mmunit.nanometer]
-    >>> assert isinstance(function(seq), list)
-    >>> assert all(isinstance(item, units.Unit) for item in function(seq))
-    >>> dct = {"length": 3 * mmunit.angstrom, "time": 2 * mmunit.picosecond}
-    >>> assert isinstance(function(dct), dict)
-    >>> assert all(isinstance(item, units.Quantity) for item in function(dct).values())
-    """
-    signature = inspect.signature(func)
-
-    def convert(data: t.Any) -> t.Any:
-        if isinstance(data, mmunit.Quantity):
-            return Quantity(data)
-        if isinstance(data, mmunit.Unit):
-            return Unit(data)
-        if isinstance(data, str):
-            return data
-        if isinstance(data, t.Sequence):
-            return type(data)(map(convert, data))
-        if isinstance(data, t.Dict):
-            return type(data)((key, convert(value)) for key, value in data.items())
-        return data
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        bound = signature.bind(*args, **kwargs)
-        for name, data in bound.arguments.items():
-            bound.arguments[name] = convert(data)
-        return func(*bound.args, **bound.kwargs)
-
-    return wrapper
 
 
 def value_in_md_units(

--- a/cvpack/utils.py
+++ b/cvpack/utils.py
@@ -15,9 +15,9 @@ import numpy as np
 import openmm
 from numpy import typing as npt
 from openmm import XmlSerializer
-from openmm import unit as mmunit
+from openmm import unit as mmunit, app as mmapp
 
-from .serialization import Serializable
+from .serialization import Serializable, SerializableAtom, SerializableResidue
 from .units import Quantity, Unit, value_in_md_units
 
 # pylint: disable=protected-access,c-extension-no-member
@@ -252,10 +252,10 @@ def compute_effective_mass(force: openmm.Force, context: openmm.Context) -> floa
     return 1.0 / np.sum(squared_forces[nonzeros] / mass_values)
 
 
-def preprocess_units(func: t.Callable) -> t.Callable:
+def preprocess_args(func: t.Callable) -> t.Callable:
     """
-    A decorator that converts instances of openmm.unit.Unit and openmm.unit.Quantity
-    into openxps.units.Unit and openxps.units.Quantity, respectively.
+    A decorator that converts instances of unserializable classes to their
+    serializable counterparts.
 
     Parameters
     ----------
@@ -289,6 +289,10 @@ def preprocess_units(func: t.Callable) -> t.Callable:
             return Quantity(data)
         if isinstance(data, mmunit.Unit):
             return Unit(data)
+        if isinstance(data, mmapp.Atom):
+            return SerializableAtom(data)
+        if isinstance(data, mmapp.Residue):
+            return SerializableResidue(data)
         if isinstance(data, str):
             return data
         if isinstance(data, t.Sequence):


### PR DESCRIPTION
## Description

When registering a CV, arguments are automatically converted to serializable classed when needed.