### PR TITLE
Exposes the base `CollectiveVariable` class

### DIFF
--- a/cvpack/__init__.py
+++ b/cvpack/__init__.py
@@ -1,10 +1,15 @@
-"""Useful Collective Variables for OpenMM"""
+"""
+.. package:: cvpack
+    :platform: Linux, MacOS, Windows
+    :synopsis: Collective Variables for Molecular Dynamics Simulations with OpenMM
+"""
 
 from ._version import __version__  # noqa: F401
 from .angle import Angle  # noqa: F401
 from .atomic_function import AtomicFunction  # noqa: F401
 from .attraction_strength import AttractionStrength  # noqa: F401
 from .centroid_function import CentroidFunction  # noqa: F401
+from .collective_variable import CollectiveVariable  # noqa: F401
 from .composite_rmsd import CompositeRMSD  # noqa: F401
 from .distance import Distance  # noqa: F401
 from .helix_angle_content import HelixAngleContent  # noqa: F401

--- a/cvpack/angle.py
+++ b/cvpack/angle.py
@@ -11,10 +11,10 @@ import numpy as np
 import openmm
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 
 
-class Angle(openmm.CustomAngleForce, BaseCollectiveVariable):
+class Angle(openmm.CustomAngleForce, CollectiveVariable):
     r"""
     The angle formed by three atoms:
 

--- a/cvpack/attraction_strength.py
+++ b/cvpack/attraction_strength.py
@@ -12,14 +12,14 @@ import typing as t
 import openmm
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import ScalarQuantity
 from .utils import evaluate_in_context
 
 ONE_4PI_EPS0 = 138.93545764438198
 
 
-class AttractionStrength(openmm.CustomNonbondedForce, BaseCollectiveVariable):
+class AttractionStrength(openmm.CustomNonbondedForce, CollectiveVariable):
     r"""
     The strength of the attraction between two atom groups:
 

--- a/cvpack/base_custom_function.py
+++ b/cvpack/base_custom_function.py
@@ -11,11 +11,11 @@ import typing as t
 
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import ScalarQuantity, VectorQuantity, value_in_md_units
 
 
-class BaseCustomFunction(BaseCollectiveVariable):
+class BaseCustomFunction(CollectiveVariable):
     """
     Abstract class for collective variables defined by a custom function.
     """

--- a/cvpack/base_radius_of_gyration.py
+++ b/cvpack/base_radius_of_gyration.py
@@ -11,10 +11,10 @@ import typing as t
 
 import openmm
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 
 
-class BaseRadiusOfGyration(openmm.CustomCentroidBondForce, BaseCollectiveVariable):
+class BaseRadiusOfGyration(openmm.CustomCentroidBondForce, CollectiveVariable):
     """
     Abstract class for the radius of gyration of a group of `n` atoms.
     """

--- a/cvpack/base_rmsd.py
+++ b/cvpack/base_rmsd.py
@@ -11,11 +11,11 @@ import typing as t
 
 import numpy as np
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import MatrixQuantity, VectorQuantity, value_in_md_units
 
 
-class BaseRMSD(BaseCollectiveVariable):
+class BaseRMSD(CollectiveVariable):
     r"""
     A base class for root-mean-square deviation (RMSD) collective variables.
     """

--- a/cvpack/base_rmsd_content.py
+++ b/cvpack/base_rmsd_content.py
@@ -14,12 +14,12 @@ import numpy as np
 import openmm
 from openmm import app as mmapp
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .rmsd import RMSD
 from .units import ScalarQuantity, value_in_md_units
 
 
-class BaseRMSDContent(openmm.CustomCVForce, BaseCollectiveVariable):
+class BaseRMSDContent(openmm.CustomCVForce, CollectiveVariable):
     """
     Abstract class for secondary-structure RMSD content of a sequence of `n` residues.
     """

--- a/cvpack/distance.py
+++ b/cvpack/distance.py
@@ -10,10 +10,10 @@
 import openmm
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 
 
-class Distance(openmm.CustomBondForce, BaseCollectiveVariable):
+class Distance(openmm.CustomBondForce, CollectiveVariable):
     r"""
     The distance between two atoms:
 

--- a/cvpack/helix_angle_content.py
+++ b/cvpack/helix_angle_content.py
@@ -13,11 +13,11 @@ import openmm
 from openmm import app as mmapp
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import ScalarQuantity
 
 
-class HelixAngleContent(openmm.CustomAngleForce, BaseCollectiveVariable):
+class HelixAngleContent(openmm.CustomAngleForce, CollectiveVariable):
     r"""
     The alpha-helix angle content of a sequence of `n` residues:
 

--- a/cvpack/helix_hbond_content.py
+++ b/cvpack/helix_hbond_content.py
@@ -14,11 +14,11 @@ import openmm
 from openmm import app as mmapp
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import ScalarQuantity
 
 
-class HelixHBondContent(openmm.CustomBondForce, BaseCollectiveVariable):
+class HelixHBondContent(openmm.CustomBondForce, CollectiveVariable):
     r"""
     The alpha-helix hydrogen-bond content of a sequence of `n` residues:
 

--- a/cvpack/helix_torsion_content.py
+++ b/cvpack/helix_torsion_content.py
@@ -13,11 +13,11 @@ import openmm
 from openmm import app as mmapp
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import ScalarQuantity
 
 
-class HelixTorsionContent(openmm.CustomTorsionForce, BaseCollectiveVariable):
+class HelixTorsionContent(openmm.CustomTorsionForce, CollectiveVariable):
     r"""
     The alpha-helix Ramachandran content of a sequence of `n` residues:
 

--- a/cvpack/number_of_contacts.py
+++ b/cvpack/number_of_contacts.py
@@ -13,12 +13,12 @@ from numbers import Real
 import openmm
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import ScalarQuantity
 from .utils import evaluate_in_context
 
 
-class NumberOfContacts(openmm.CustomNonbondedForce, BaseCollectiveVariable):
+class NumberOfContacts(openmm.CustomNonbondedForce, CollectiveVariable):
     r"""
     The number of contacts between two atom groups:
 

--- a/cvpack/openmm_force_wrapper.py
+++ b/cvpack/openmm_force_wrapper.py
@@ -12,11 +12,11 @@ import typing as t
 import openmm
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import Unit, VectorQuantity
 
 
-class OpenMMForceWrapper(BaseCollectiveVariable):
+class OpenMMForceWrapper(CollectiveVariable):
     r"""
     A collective variable whose numerical value is computed from the potential energy,
     in kJ/mol, of an OpenMM force object.
@@ -39,30 +39,31 @@ class OpenMMForceWrapper(BaseCollectiveVariable):
     name
         The name of the collective variable.
 
-    Example:
-        >>> import cvpack
-        >>> import numpy as np
-        >>> import openmm
-        >>> from openmm import unit
-        >>> from openmmtools import testsystems
-        >>> model = testsystems.AlanineDipeptideVacuum()
-        >>> angle = openmm.CustomAngleForce("theta")
-        >>> _ = angle.addAngle(0, 1, 2)
-        >>> cv = cvpack.OpenMMForceWrapper(
-        ...     angle,
-        ...     unit.radian,
-        ...     periodicBounds=[-np.pi, np.pi] * unit.radian,
-        ... )
-        >>> assert isinstance(cv, openmm.CustomAngleForce)
-        >>> cv.addToSystem(model.system)
-        >>> integrator = openmm.VerletIntegrator(0)
-        >>> platform = openmm.Platform.getPlatformByName("Reference")
-        >>> context = openmm.Context(model.system, integrator, platform)
-        >>> context.setPositions(model.positions)
-        >>> cv.getValue(context)
-        1.911... rad
-        >>> cv.getEffectiveMass(context)
-        0.00538... nm**2 Da/(rad**2)
+    Example
+    -------
+    >>> import cvpack
+    >>> import numpy as np
+    >>> import openmm
+    >>> from openmm import unit
+    >>> from openmmtools import testsystems
+    >>> model = testsystems.AlanineDipeptideVacuum()
+    >>> angle = openmm.CustomAngleForce("theta")
+    >>> _ = angle.addAngle(0, 1, 2)
+    >>> cv = cvpack.OpenMMForceWrapper(
+    ...     angle,
+    ...     unit.radian,
+    ...     periodicBounds=[-np.pi, np.pi] * unit.radian,
+    ... )
+    >>> assert isinstance(cv, openmm.CustomAngleForce)
+    >>> cv.addToSystem(model.system)
+    >>> integrator = openmm.VerletIntegrator(0)
+    >>> platform = openmm.Platform.getPlatformByName("Reference")
+    >>> context = openmm.Context(model.system, integrator, platform)
+    >>> context.setPositions(model.positions)
+    >>> cv.getValue(context)
+    1.911... rad
+    >>> cv.getEffectiveMass(context)
+    0.00538... nm**2 Da/(rad**2)
     """
 
     def __init__(  # pylint: disable=super-init-not-called
@@ -77,7 +78,7 @@ class OpenMMForceWrapper(BaseCollectiveVariable):
         unit = Unit(unit)
         force_copy = openmm.XmlSerializer.deserialize(openmmForce)
         self.this = force_copy.this
-        self.__class__.__bases__ = (BaseCollectiveVariable, type(force_copy))
+        self.__class__.__bases__ = (CollectiveVariable, type(force_copy))
         self._registerCV(name, unit, openmmForce, unit, periodicBounds)
         if periodicBounds is not None:
             self._registerPeriodicBounds(*periodicBounds)

--- a/cvpack/path_in_cv_space.py
+++ b/cvpack/path_in_cv_space.py
@@ -13,13 +13,13 @@ from copy import deepcopy
 
 import openmm
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .path import Metric, deviation, progress
 from .units.units import MatrixQuantity, ScalarQuantity, value_in_md_units
 from .utils import convert_to_matrix
 
 
-class PathInCVSpace(openmm.CustomCVForce, BaseCollectiveVariable):
+class PathInCVSpace(openmm.CustomCVForce, CollectiveVariable):
     r"""
     A metric of the system's progress (:math:`s`) or deviation (:math:`z`) with
     respect to a path defined by a sequence of :math:`n` milestones positioned in a
@@ -123,7 +123,7 @@ class PathInCVSpace(openmm.CustomCVForce, BaseCollectiveVariable):
     def __init__(  # pylint: disable=too-many-branches
         self,
         metric: Metric,
-        variables: t.Iterable[BaseCollectiveVariable],
+        variables: t.Iterable[CollectiveVariable],
         milestones: MatrixQuantity,
         sigma: float,
         scales: t.Optional[t.Iterable[ScalarQuantity]] = None,

--- a/cvpack/residue_coordination.py
+++ b/cvpack/residue_coordination.py
@@ -14,11 +14,11 @@ from openmm import unit as mmunit
 from openmm.app.element import hydrogen
 from openmm.app.topology import Residue
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 from .units import ScalarQuantity, value_in_md_units
 
 
-class ResidueCoordination(openmm.CustomCentroidBondForce, BaseCollectiveVariable):
+class ResidueCoordination(openmm.CustomCentroidBondForce, CollectiveVariable):
     r"""
     The number of contacts between two disjoint groups of residues:
 

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -49,12 +49,12 @@ def test_effective_mass():
 
 def test_argument_inspection():
     """
-    Test argument inspection of a arbitrary BaseCollectiveVariable subclass
+    Test argument inspection of a arbitrary CollectiveVariable subclass
 
     """
 
     # pylint: disable=missing-class-docstring, unused-argument
-    class Test(cvpack.cvpack.BaseCollectiveVariable):
+    class Test(cvpack.CollectiveVariable):
         def __init__(self, first: int, second: float, third: str = "3"):
             super().__init__(self)
 
@@ -68,7 +68,7 @@ def test_argument_inspection():
 
 
 def perform_common_tests(
-    collectiveVariable: cvpack.cvpack.BaseCollectiveVariable,
+    collectiveVariable: cvpack.CollectiveVariable,
     context: openmm.Context,
 ) -> None:
     """

--- a/cvpack/torsion.py
+++ b/cvpack/torsion.py
@@ -11,10 +11,10 @@ import numpy as np
 import openmm
 from openmm import unit as mmunit
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 
 
-class Torsion(openmm.CustomTorsionForce, BaseCollectiveVariable):
+class Torsion(openmm.CustomTorsionForce, CollectiveVariable):
     r"""
     The torsion angle formed by four atoms:
 

--- a/cvpack/torsion_similarity.py
+++ b/cvpack/torsion_similarity.py
@@ -11,10 +11,10 @@ import numpy as np
 import openmm
 from numpy.typing import ArrayLike
 
-from .cvpack import BaseCollectiveVariable
+from .collective_variable import CollectiveVariable
 
 
-class TorsionSimilarity(openmm.CustomCompoundBondForce, BaseCollectiveVariable):
+class TorsionSimilarity(openmm.CustomCompoundBondForce, CollectiveVariable):
     r"""
     The degree of similarity between `n` pairs of torsion angles:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,14 +20,14 @@ import sys
 
 # Incase the project was not installed
 import cvpack
-from cvpack.cvpack import BaseCollectiveVariable
+from cvpack import CollectiveVariable
 
 sys.path.insert(0, os.path.abspath(".."))
 
 
 def create_rst_file(cls):
     name = cls.__name__
-    methods = list(BaseCollectiveVariable.__dict__.keys()) + list(cls.__dict__.keys())
+    methods = list(CollectiveVariable.__dict__.keys()) + list(cls.__dict__.keys())
     excluded = ["yaml_tag"]
     with open(f"api/{name}.rst", "w") as f:
         f.writelines(
@@ -50,7 +50,11 @@ def create_rst_file(cls):
 with open("api/index.rst", "w") as f:
     f.write("Python API\n==========\n\n.. toctree::\n    :titlesonly:\n\n")
     for item in cvpack.__dict__.values():
-        if inspect.isclass(item):
+        if (
+            inspect.isclass(item)
+            and item is not CollectiveVariable
+            and issubclass(item, CollectiveVariable)
+        ):
             f.write(f"    {item.__name__}\n")
             create_rst_file(item)
     f.write("\n.. testsetup::\n\n    from cvpack import *")


### PR DESCRIPTION
## Description

Exposes the base class for all collective variables and requires explicit authorization for reinitializing the context when evaluating a CV or its effective mass.