### PR TITLE
Includes a collective variable reporter for OpenMM simulations

### DIFF
--- a/cvpack/collective_variable.py
+++ b/cvpack/collective_variable.py
@@ -36,10 +36,10 @@ class CollectiveVariable(openmm.Force, Serializable):
     def __setstate__(self, keywords: t.Dict[str, t.Any]) -> None:
         self.__init__(**keywords)
 
-    def __copy__(self):
+    def __copy__(self) -> "CollectiveVariable":
         return yaml.safe_load(yaml.safe_dump(self))
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, _) -> "CollectiveVariable":
         return yaml.safe_load(yaml.safe_dump(self))
 
     @preprocess_args
@@ -72,7 +72,9 @@ class CollectiveVariable(openmm.Force, Serializable):
         self._unit = Unit("dimensionless") if unit is None else unit
         self._mass_unit = Unit(mmunit.dalton * (mmunit.nanometers / self._unit) ** 2)
         arguments, _ = self._getArguments()
+        arguments.pop("name")
         self._args = dict(zip(arguments, args))
+        self._args["name"] = name
         self._args.update(kwargs)
 
     def _registerPeriodicBounds(

--- a/cvpack/reporting/__init__.py
+++ b/cvpack/reporting/__init__.py
@@ -1,0 +1,6 @@
+"""
+Reporting subpackage of CVPack
+
+"""
+
+from .reporting import CollectiveVariableReporter  # noqa: F401

--- a/cvpack/reporting/reporting.py
+++ b/cvpack/reporting/reporting.py
@@ -1,0 +1,146 @@
+"""
+.. module:: reporting
+   :platform: Linux, MacOS, Windows
+   :synopsis: This module provides classes for reporting simulation data
+
+.. moduleauthor:: Charlles Abreu <craabreu@gmail.com>
+
+"""
+
+import io
+import typing as t
+from collections import OrderedDict
+
+import openmm
+from openmm import app as mmapp
+from openmm import unit as mmunit
+
+from ..collective_variable import CollectiveVariable
+from ..meta_collective_variable import MetaCollectiveVariable as MetaCV
+
+
+class CollectiveVariableReporter(mmapp.StateDataReporter):
+    """
+    Reports values and effective masses of collective variables during a simulation.
+
+    To use it, create a :class:`CollectiveVariableReporter`, then add it to the
+    :class:`~openmm.app.Simulation`'s list of reporters. The set of data to write is
+    configurable using boolean flags passed to the constructor.
+
+    By default the data is written in comma-separated-value (CSV) format, but you can
+    specify a different separator to use.
+
+    Parameters
+    ----------
+    file
+        The file to write to, specified as a file name or file object.
+    reportInterval
+        The interval (in time steps) at which to write frames.
+    variables
+        The collective variables to report.
+    step
+        Whether to write the current step index to the file.
+    time
+        Whether to write the current time to the file.
+    values
+        Whether to write the current values of the collective variables to the file.
+    effectiveMasses
+        Whether to write the current effective masses of the collective variables to
+        the file.
+    excludeInnerVariables
+        Whether to exclude the inner collective variables of meta-collective variables
+        from the report.
+    separator
+        The separator to use between columns in the file.
+    append
+        If `True`, omit the header line and append the report to an existing file.
+
+    Raises
+    ------
+    ValueError
+        If `variables` is empty.
+    ValueError
+        If `values` and `effectiveMasses` are both `False`.
+    """
+
+    def __init__(
+        self,
+        file: t.Union[str, io.TextIOBase],
+        reportInterval: int,
+        variables: t.Sequence[CollectiveVariable],
+        step: bool = False,
+        time: bool = False,
+        values: bool = False,
+        effectiveMasses: bool = False,
+        excludeInnerVariables: bool = False,
+        separator: str = ",",
+        append: bool = False,
+    ) -> None:
+        if not variables:
+            raise ValueError("Argument 'variables' cannot be empty")
+        if not (values or effectiveMasses):
+            raise ValueError(
+                "Arguments 'values' and 'effectiveMasses' cannot be both False"
+            )
+        super().__init__(
+            file,
+            reportInterval,
+            step=step,
+            time=time,
+            separator=separator,
+            append=append,
+        )
+        self._variables = variables
+        self._values = values
+        self._effective_masses = effectiveMasses
+        self._exclude_inner_cvs = excludeInnerVariables
+
+    def _constructReportValues(  # pylint: disable=too-many-branches
+        self, simulation: mmapp.Simulation, state: openmm.State
+    ) -> t.List[float]:
+        values = []
+        if self._step:
+            values.append(simulation.currentStep)
+        if self._time:
+            values.append(state.getTime().value_in_unit(mmunit.picosecond))
+        context = simulation.context
+        cv_values = OrderedDict()
+        if self._values:
+            for cv in self._variables:
+                cv_values[cv.getName()] = cv.getValue(context)
+                if isinstance(cv, MetaCV) and not self._exclude_inner_cvs:
+                    for name, value in cv.getInnerValues(context).items():
+                        cv_values[name] = value
+        cv_masses = OrderedDict()
+        if self._effective_masses:
+            for cv in self._variables:
+                cv_masses[cv.getName()] = cv.getEffectiveMass(context)
+                if isinstance(cv, MetaCV) and not self._exclude_inner_cvs:
+                    for name, mass in cv.getInnerEffectiveMasses(context).items():
+                        cv_masses[name] = mass
+        for name in cv_values if self._values else cv_masses:
+            if name in cv_values:
+                values.append(cv_values[name] / cv_values[name].unit)
+            if name in cv_masses:
+                values.append(cv_masses[name] / cv_masses[name].unit)
+        return values
+
+    def _constructHeaders(self) -> t.List[str]:
+        headers = []
+        if self._step:
+            headers.append("Step")
+        if self._time:
+            headers.append("Time (ps)")
+
+        def add_headers(cv: CollectiveVariable) -> None:
+            if self._values:
+                headers.append(f"{cv.getName()} ({cv.getUnit()})")
+            if self._effective_masses:
+                headers.append(f"mass[{cv.getName}] ({cv.getMassUnit()})")
+
+        for variable in self._variables:
+            add_headers(variable)
+            if isinstance(variable, MetaCV) and not self._exclude_inner_cvs:
+                for inner in variable.getInnerCollectiveVariables():
+                    add_headers(inner)
+        return headers

--- a/cvpack/reporting/reporting.py
+++ b/cvpack/reporting/reporting.py
@@ -24,8 +24,8 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
     Reports values and effective masses of collective variables during a simulation.
 
     To use it, create a :class:`CollectiveVariableReporter`, then add it to the
-    :class:`~openmm.app.Simulation`'s list of reporters. The set of data to write is
-    configurable using boolean flags passed to the constructor.
+    simulation's list of reporters. The set of data to write is configurable using
+    boolean flags passed to the constructor.
 
     By default the data is written in comma-separated-value (CSV) format, but you can
     specify a different separator to use.
@@ -73,16 +73,25 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
     >>> model = testsystems.AlanineDipeptideVacuum()
     >>> phi = cvpack.Torsion(6, 8, 14, 16, name="phi")
     >>> umbrella = cvpack.MetaCollectiveVariable(
-    ...     f"50*min(delta,2*pi-delta)^2; delta=abs(phi-5*pi/6); pi={pi}",
+    ...     f"50*min(delta,2*pi-delta)^2"
+    ...     "; delta=abs(phi-5*pi/6)"
+    ...     f"; pi={pi}",
     ...     [phi],
     ...     mmunit.kilojoules_per_mole,
     ...     name="umbrella"
     ... )
     >>> reporter = cvpack.reporting.CollectiveVariableReporter(
-    ...     stdout, 1, [umbrella], step=True, values=True, effectiveMasses=True
+    ...     stdout,
+    ...     1,
+    ...     [umbrella],
+    ...     step=True,
+    ...     values=True,
+    ...     effectiveMasses=True
     ... )
     >>> integrator = openmm.LangevinIntegrator(
-    ...     300 * mmunit.kelvin, 1 / mmunit.picosecond, 2 * mmunit.femtosecond,
+    ...     300 * mmunit.kelvin,
+    ...     1 / mmunit.picosecond,
+    ...     2 * mmunit.femtosecond,
     ... )
     >>> integrator.setRandomNumberSeed(1234)
     >>> umbrella.addToSystem(model.system)

--- a/cvpack/reporting/reporting.py
+++ b/cvpack/reporting/reporting.py
@@ -186,9 +186,7 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
             if self._values:
                 headers.append(f"{cv.getName()} ({cv.getUnit().get_symbol()})")
             if self._effective_masses:
-                headers.append(
-                    f"{cv.getName()} mass ({cv.getMassUnit().get_symbol()})"
-                )
+                headers.append(f"{cv.getName()} mass ({cv.getMassUnit().get_symbol()})")
 
         for variable in self._variables:
             add_headers(variable)

--- a/cvpack/reporting/reporting.py
+++ b/cvpack/reporting/reporting.py
@@ -66,7 +66,7 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
     --------
     >>> import cvpack
     >>> import openmm
-    >>> import openmm.app as mmapp
+    >>> from openmm import app, unit
     >>> from math import pi
     >>> from sys import stdout
     >>> from openmmtools import testsystems
@@ -77,40 +77,40 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
     ...     "; delta=abs(phi-5*pi/6)"
     ...     f"; pi={pi}",
     ...     [phi],
-    ...     mmunit.kilojoules_per_mole,
+    ...     unit.kilojoules_per_mole,
     ...     name="umbrella"
     ... )
     >>> reporter = cvpack.reporting.CollectiveVariableReporter(
     ...     stdout,
-    ...     1,
+    ...     100,
     ...     [umbrella],
     ...     step=True,
     ...     values=True,
     ...     effectiveMasses=True
     ... )
     >>> integrator = openmm.LangevinIntegrator(
-    ...     300 * mmunit.kelvin,
-    ...     1 / mmunit.picosecond,
-    ...     2 * mmunit.femtosecond,
+    ...     300 * unit.kelvin,
+    ...     1 / unit.picosecond,
+    ...     2 * unit.femtosecond,
     ... )
     >>> integrator.setRandomNumberSeed(1234)
     >>> umbrella.addToSystem(model.system)
-    >>> simulation = mmapp.Simulation(model.topology, model.system, integrator)
+    >>> simulation = app.Simulation(model.topology, model.system, integrator)
     >>> simulation.context.setPositions(model.positions)
-    >>> simulation.context.setVelocitiesToTemperature(300 * mmunit.kelvin, 5678)
+    >>> simulation.context.setVelocitiesToTemperature(300 * unit.kelvin, 5678)
     >>> simulation.reporters.append(reporter)
-    >>> simulation.step(10)
-    #"Step","umbrella (kJ/mol)",...,"phi mass (nm**2 Da/(rad**2))"
-    1,13.049...,1.885...e-05,3.1288...,0.04920...
-    2,12.247...,1.962...e-05,3.1129...,0.04807...
-    3,11.420...,2.093...e-05,3.0959...,0.04782...
-    4,10.612...,2.287...e-05,3.0786...,0.04854...
-    5,9.7988...,2.550...e-05,3.0606...,0.04999...
-    6,9.0313...,2.852...e-05,3.0429...,0.05153...
-    7,8.3753...,3.141...e-05,3.0272...,0.05262...
-    8,7.7821...,3.415...e-05,3.0125...,0.05316...
-    9,7.2126...,3.665...e-05,2.9978...,0.05287...
-    10,6.563...,3.967...e-05,2.9803...,0.05208...
+    >>> simulation.step(1000)  # doctest: +SKIP
+    #"Step","umbrella (kJ/mol)",...,"phi (rad)","phi mass (nm**2 Da/(rad**2))"
+    100,0.3834...,0.00062...,2.5304...,0.04792...
+    200,0.2180...,0.00117...,2.6840...,0.05114...
+    300,0.0144...,0.01772...,2.6009...,0.05122...
+    400,0.6639...,0.00035...,2.5027...,0.04688...
+    500,0.1658...,0.00138...,2.6755...,0.04585...
+    600,1.5860...,0.00015...,2.7960...,0.04875...
+    700,4.0932...,0.00005...,2.3318...,0.04457...
+    800,3.8208...,0.00006...,2.8944...,0.04639...
+    900,1.2252...,0.00017...,2.4614...,0.04213...
+    1000,0.564...,0.00044...,2.5117...,0.05042...
     """
 
     def __init__(

--- a/cvpack/reporting/reporting.py
+++ b/cvpack/reporting/reporting.py
@@ -9,47 +9,49 @@
 
 import io
 import typing as t
-from collections import OrderedDict
 
 import openmm
 from openmm import app as mmapp
 from openmm import unit as mmunit
 
 from ..collective_variable import CollectiveVariable
-from ..meta_collective_variable import MetaCollectiveVariable as MetaCV
+from ..meta_collective_variable import MetaCollectiveVariable
 
 
 class CollectiveVariableReporter(mmapp.StateDataReporter):
     """
-    Reports values and effective masses of collective variables during a simulation.
+    Reports values and/or effective masses of collective variables during an OpenMM
+    `Simulation`_.
 
-    To use it, create a :class:`CollectiveVariableReporter`, then add it to the
-    simulation's list of reporters. The set of data to write is configurable using
-    boolean flags passed to the constructor.
+    Create a :class:`CollectiveVariableReporter` add it to the `Simulation`_'s list
+    of reporters (see example below). The reporter writes data to a file or file-like
+    object at regular intervals. The set of data to write is configurable using boolean
+    flags passed to the constructor. The data is written in comma-separated-value (CSV)
+    format by default, but the user can specify a different separator.
 
-    By default the data is written in comma-separated-value (CSV) format, but you can
-    specify a different separator to use.
+    .. _Simulation: http://docs.openmm.org/latest/api-python/generated/
+        openmm.app.simulation.Simulation.html
 
     Parameters
     ----------
     file
-        The file to write to, specified as a file name or file object.
+        The file to write to. This can be a file name or a file object.
     reportInterval
-        The interval (in time steps) at which to write frames.
+        The interval (in time steps) at which to report data.
     variables
-        The collective variables to report.
+        The collective variable whose values and/or effective masses will be reported.
+        These must be the same objects added to the simulation's :OpenMM:`System`.
+    metaCVs
+        The meta-collective variables whose inner variables will be reported. These must
+        be the same objects added to the simulation's :OpenMM:`System`.
     step
-        Whether to write the current step index to the file.
+        Whether to report the current step index.
     time
-        Whether to write the current time to the file.
+        Whether to report the current simulation time.
     values
-        Whether to write the current values of the collective variables to the file.
-    effectiveMasses
-        Whether to write the current effective masses of the collective variables to
-        the file.
-    excludeInnerVariables
-        Whether to exclude the inner collective variables of meta-collective variables
-        from the report.
+        Whether to report the current values of the collective variables.
+    masses
+        Whether to report the current effective masses of the collective variables.
     separator
         The separator to use between columns in the file.
     append
@@ -58,35 +60,37 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
     Raises
     ------
     ValueError
-        If `variables` is empty.
+        If `variables` and `metaCVs` are both empty.
     ValueError
-        If `values` and `effectiveMasses` are both `False`.
+        If `values` and `masses` are both `False`.
 
     Examples
     --------
     >>> import cvpack
+    >>> from cvpack import reporting
     >>> import openmm
     >>> from openmm import app, unit
-    >>> from math import pi
     >>> from sys import stdout
     >>> from openmmtools import testsystems
     >>> model = testsystems.AlanineDipeptideVacuum()
     >>> phi = cvpack.Torsion(6, 8, 14, 16, name="phi")
+    >>> psi = cvpack.Torsion(8, 14, 16, 18, name="psi")
     >>> umbrella = cvpack.MetaCollectiveVariable(
-    ...     f"50*min(delta,2*pi-delta)^2"
-    ...     "; delta=abs(phi-5*pi/6)"
-    ...     f"; pi={pi}",
-    ...     [phi],
+    ...     "50*(min(dphi,2*pi-dphi)^2+min(dpsi,2*pi-dpsi)^2)"
+    ...     "; dphi=abs(phi-5*pi/6); dpsi=abs(psi+5*pi/6)",
+    ...     [phi, psi],
     ...     unit.kilojoules_per_mole,
-    ...     name="umbrella"
+    ...     name="umbrella",
+    ...     pi=3.141592653589793,
     ... )
-    >>> reporter = cvpack.reporting.CollectiveVariableReporter(
+    >>> reporter = reporting.CollectiveVariableReporter(
     ...     stdout,
     ...     100,
-    ...     [umbrella],
+    ...     variables=[umbrella],
+    ...     metaCVs=[umbrella],
     ...     step=True,
     ...     values=True,
-    ...     effectiveMasses=True
+    ...     masses=True
     ... )
     >>> integrator = openmm.LangevinIntegrator(
     ...     300 * unit.kelvin,
@@ -99,39 +103,37 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
     >>> simulation.context.setPositions(model.positions)
     >>> simulation.context.setVelocitiesToTemperature(300 * unit.kelvin, 5678)
     >>> simulation.reporters.append(reporter)
-    >>> simulation.step(1000)  # doctest: +SKIP
-    #"Step","umbrella (kJ/mol)",...,"phi (rad)","phi mass (nm**2 Da/(rad**2))"
-    100,0.3834...,0.00062...,2.5304...,0.04792...
-    200,0.2180...,0.00117...,2.6840...,0.05114...
-    300,0.0144...,0.01772...,2.6009...,0.05122...
-    400,0.6639...,0.00035...,2.5027...,0.04688...
-    500,0.1658...,0.00138...,2.6755...,0.04585...
-    600,1.5860...,0.00015...,2.7960...,0.04875...
-    700,4.0932...,0.00005...,2.3318...,0.04457...
-    800,3.8208...,0.00006...,2.8944...,0.04639...
-    900,1.2252...,0.00017...,2.4614...,0.04213...
-    1000,0.564...,0.00044...,2.5117...,0.05042...
+    >>> simulation.step(1000)
+    #"Step","umbrella (kJ/mol)",...,"psi mass (nm**2 Da/(rad**2))"
+    100,11.2618...,1.8774...e-05,2.3684...,0.04388...,-3.0217...,0.05552...
+    200,7.46382...,4.8803...e-05,2.8851...,0.04968...,-2.8971...,0.05230...
+    300,2.55804...,8.9086...e-05,2.4311...,0.04637...,-2.4905...,0.03721...
+    400,6.19945...,4.6824...e-05,2.9678...,0.05449...,-2.6577...,0.04840...
+    500,8.82728...,3.0253...e-05,2.5838...,0.04584...,-3.0367...,0.05485...
+    600,3.76160...,7.9099...e-05,2.7248...,0.04772...,-2.8706...,0.05212...
+    700,3.38895...,6.3273...e-05,2.5583...,0.04999...,-2.8714...,0.04674...
+    800,1.07166...,0.00028746...,2.7104...,0.05321...,-2.7314...,0.05418...
+    900,8.58602...,2.4899...e-05,2.4391...,0.04096...,-2.9917...,0.04675...
+    1000,5.8404...,5.1011...e-05,2.7584...,0.04951...,-2.9295...,0.05030...
     """
 
     def __init__(
         self,
         file: t.Union[str, io.TextIOBase],
         reportInterval: int,
-        variables: t.Sequence[CollectiveVariable],
+        variables: t.Sequence[CollectiveVariable] = (),
+        metaCVs: t.Sequence[MetaCollectiveVariable] = (),
         step: bool = False,
         time: bool = False,
         values: bool = False,
-        effectiveMasses: bool = False,
-        excludeInnerVariables: bool = False,
+        masses: bool = False,
         separator: str = ",",
         append: bool = False,
     ) -> None:
-        if not variables:
-            raise ValueError("Argument 'variables' cannot be empty")
-        if not (values or effectiveMasses):
-            raise ValueError(
-                "Arguments 'values' and 'effectiveMasses' cannot be both False"
-            )
+        if not (variables or metaCVs):
+            raise ValueError("Arguments 'variables' and 'metaCVs' cannot be both empty")
+        if not (values or masses):
+            raise ValueError("Arguments 'values' and 'masses' cannot be both False")
         super().__init__(
             file,
             reportInterval,
@@ -141,9 +143,9 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
             append=append,
         )
         self._variables = variables
+        self._meta_cvs = metaCVs
         self._values = values
-        self._effective_masses = effectiveMasses
-        self._exclude_inner_cvs = excludeInnerVariables
+        self._masses = masses
 
     def _constructReportValues(  # pylint: disable=too-many-branches
         self, simulation: mmapp.Simulation, state: openmm.State
@@ -154,25 +156,19 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
         if self._time:
             values.append(state.getTime().value_in_unit(mmunit.picosecond))
         context = simulation.context
-        cv_values = OrderedDict()
-        if self._values:
-            for cv in self._variables:
-                cv_values[cv.getName()] = cv.getValue(context)
-                if isinstance(cv, MetaCV) and not self._exclude_inner_cvs:
-                    for name, value in cv.getInnerValues(context).items():
-                        cv_values[name] = value
-        cv_masses = OrderedDict()
-        if self._effective_masses:
-            for cv in self._variables:
-                cv_masses[cv.getName()] = cv.getEffectiveMass(context)
-                if isinstance(cv, MetaCV) and not self._exclude_inner_cvs:
-                    for name, mass in cv.getInnerEffectiveMasses(context).items():
-                        cv_masses[name] = mass
-        for name in cv_values if self._values else cv_masses:
-            if name in cv_values:
-                values.append(cv_values[name] / cv_values[name].unit)
-            if name in cv_masses:
-                values.append(cv_masses[name] / cv_masses[name].unit)
+        for cv in self._variables:
+            if self._values:
+                values.append(cv.getValue(context) / cv.getUnit())
+            if self._masses:
+                values.append(cv.getEffectiveMass(context) / cv.getMassUnit())
+        for cv in self._meta_cvs:
+            cv_values = cv.getInnerValues(context) if self._values else {}
+            cv_masses = cv.getInnerEffectiveMasses(context) if self._masses else {}
+            for name in cv_values if self._values else cv_masses:
+                if name in cv_values:
+                    values.append(cv_values[name] / cv_values[name].unit)
+                if name in cv_masses:
+                    values.append(cv_masses[name] / cv_masses[name].unit)
         return values
 
     def _constructHeaders(self) -> t.List[str]:
@@ -185,12 +181,12 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
         def add_headers(cv: CollectiveVariable) -> None:
             if self._values:
                 headers.append(f"{cv.getName()} ({cv.getUnit().get_symbol()})")
-            if self._effective_masses:
+            if self._masses:
                 headers.append(f"{cv.getName()} mass ({cv.getMassUnit().get_symbol()})")
 
-        for variable in self._variables:
-            add_headers(variable)
-            if isinstance(variable, MetaCV) and not self._exclude_inner_cvs:
-                for inner in variable.getInnerVariables():
-                    add_headers(inner)
+        for cv in self._variables:
+            add_headers(cv)
+        for cv in self._meta_cvs:
+            for inner_cv in cv.getInnerVariables():
+                add_headers(inner_cv)
         return headers

--- a/cvpack/reporting/reporting.py
+++ b/cvpack/reporting/reporting.py
@@ -103,7 +103,7 @@ class CollectiveVariableReporter(mmapp.StateDataReporter):
     >>> simulation.context.setPositions(model.positions)
     >>> simulation.context.setVelocitiesToTemperature(300 * unit.kelvin, 5678)
     >>> simulation.reporters.append(reporter)
-    >>> simulation.step(1000)
+    >>> simulation.step(1000)  # doctest: +SKIP
     #"Step","umbrella (kJ/mol)",...,"psi mass (nm**2 Da/(rad**2))"
     100,11.2618...,1.8774...e-05,2.3684...,0.04388...,-3.0217...,0.05552...
     200,7.46382...,4.8803...e-05,2.8851...,0.04968...,-2.8971...,0.05230...

--- a/cvpack/reporting/tests/test_reporting.py
+++ b/cvpack/reporting/tests/test_reporting.py
@@ -23,28 +23,27 @@ def test_collective_variable_reporter():
         name="umbrella",
     )
     with tempfile.TemporaryDirectory() as dirpath:
-        reporter = cvpack.reporting.CollectiveVariableReporter(
-            os.path.join(dirpath, "report.csv"),
-            1,
-            [umbrella],
-            step=True,
-            values=True,
-            effectiveMasses=True,
-        )
         integrator = openmm.LangevinIntegrator(
-            300 * unit.kelvin,
-            1 / unit.picosecond,
-            2 * unit.femtosecond,
+            300 * unit.kelvin, 1 / unit.picosecond, 2 * unit.femtosecond
         )
         integrator.setRandomNumberSeed(1234)
         umbrella.addToSystem(model.system)
         simulation = app.Simulation(model.topology, model.system, integrator)
         simulation.context.setPositions(model.positions)
         simulation.context.setVelocitiesToTemperature(300 * unit.kelvin, 5678)
-        simulation.reporters.append(reporter)
-        simulation.step(10)
-        with open(os.path.join(dirpath, "report.csv"), "r") as f:
-            assert f.readline() == ",".join(
+        with open(os.path.join(dirpath, "report.csv"), "w") as file:
+            reporter = cvpack.reporting.CollectiveVariableReporter(
+                file,
+                1,
+                [umbrella],
+                step=True,
+                values=True,
+                effectiveMasses=True,
+            )
+            simulation.reporters.append(reporter)
+            simulation.step(10)
+        with open(os.path.join(dirpath, "report.csv"), "r") as file:
+            assert file.readline() == ",".join(
                 [
                     '#"Step"',
                     '"umbrella (kJ/mol)"',

--- a/cvpack/reporting/tests/test_reporting.py
+++ b/cvpack/reporting/tests/test_reporting.py
@@ -36,9 +36,10 @@ def test_collective_variable_reporter():
                 file,
                 1,
                 [umbrella],
+                [umbrella],
                 step=True,
                 values=True,
-                effectiveMasses=True,
+                masses=True,
             )
             simulation.reporters.append(reporter)
             simulation.step(10)

--- a/cvpack/reporting/tests/test_reporting.py
+++ b/cvpack/reporting/tests/test_reporting.py
@@ -1,0 +1,55 @@
+"""
+Unit test for the reporting subpackage of CVPack
+"""
+
+import os
+import tempfile
+from math import pi
+
+import openmm
+from openmm import app, unit
+from openmmtools import testsystems
+
+import cvpack
+
+
+def test_collective_variable_reporter():
+    model = testsystems.AlanineDipeptideVacuum()
+    phi = cvpack.Torsion(6, 8, 14, 16, name="phi")
+    umbrella = cvpack.MetaCollectiveVariable(
+        f"50*min(delta,2*pi-delta)^2" "; delta=abs(phi-5*pi/6)" f"; pi={pi}",
+        [phi],
+        unit.kilojoules_per_mole,
+        name="umbrella",
+    )
+    with tempfile.TemporaryDirectory() as dirpath:
+        reporter = cvpack.reporting.CollectiveVariableReporter(
+            os.path.join(dirpath, "report.csv"),
+            1,
+            [umbrella],
+            step=True,
+            values=True,
+            effectiveMasses=True,
+        )
+        integrator = openmm.LangevinIntegrator(
+            300 * unit.kelvin,
+            1 / unit.picosecond,
+            2 * unit.femtosecond,
+        )
+        integrator.setRandomNumberSeed(1234)
+        umbrella.addToSystem(model.system)
+        simulation = app.Simulation(model.topology, model.system, integrator)
+        simulation.context.setPositions(model.positions)
+        simulation.context.setVelocitiesToTemperature(300 * unit.kelvin, 5678)
+        simulation.reporters.append(reporter)
+        simulation.step(10)
+        with open(os.path.join(dirpath, "report.csv"), "r") as f:
+            assert f.readline() == ",".join(
+                [
+                    '#"Step"',
+                    '"umbrella (kJ/mol)"',
+                    '"umbrella mass (nm**2 mol**2 Da/(kJ**2))"',
+                    '"phi (rad)"',
+                    '"phi mass (nm**2 Da/(rad**2))"\n',
+                ]
+            )

--- a/cvpack/serialization/__init__.py
+++ b/cvpack/serialization/__init__.py
@@ -1,5 +1,5 @@
 """
-Serializer submodule of CVPack
+Serialization subpackage of CVPack
 
 """
 

--- a/cvpack/serialization/serialization.py
+++ b/cvpack/serialization/serialization.py
@@ -144,6 +144,7 @@ def serialize(obj: t.Any, iostream: t.IO) -> None:
     - 0
     - 1
     - 2
+    name: radius_of_gyration
     pbc: false
     weighByMass: false
     <BLANKLINE>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Contents
    getting_started
    api/index
    serialization
+   reporting
    references
 
 

--- a/docs/reporting.rst
+++ b/docs/reporting.rst
@@ -1,0 +1,5 @@
+Reporting
+=========
+
+.. currentmodule:: cvpack.reporting
+.. autoclass:: CollectiveVariableReporter


### PR DESCRIPTION
## Description

This PR adds a new subpackage, `Reporting,` containing a new class, `CollectiveVariableReporter,` whose goal is to facilitate reporting CV values and effective masses during simulations.