### PR TITLE
Improves parameter handling in meta-collective variables

### DIFF
--- a/cvpack/meta_collective_variable.py
+++ b/cvpack/meta_collective_variable.py
@@ -16,7 +16,7 @@ import openmm
 from openmm import unit as mmunit
 
 from .collective_variable import CollectiveVariable
-from .units import Quantity, ScalarQuantity, VectorQuantity
+from .units import Quantity, ScalarQuantity, VectorQuantity, in_md_units, Unit
 from .utils import compute_effective_mass
 
 
@@ -65,13 +65,15 @@ class MetaCollectiveVariable(openmm.CustomCVForce, CollectiveVariable):
         `unit.dimensionless`
     periodicBounds
         The periodic bounds of the collective variable if it is periodic, or `None` if
-        it is not
+        it is not periodic.
 
     Keyword Args
     ------------
     **parameters
-        The named parameters of the function. They will become :OpenMM:`Context`
-        parameters if this collective variable is added to an :OpenMM:`System`.
+        The named parameters of the function, if any. They will become settable context
+        parameters when this meta-collective variable is added to an :OpenMM:`System`.
+        The passed objects must be scalar quantities. Their values will be converted to
+        OpenMM's MD unit system to serve as default values for the context parameters.
 
     Example
     -------
@@ -95,6 +97,12 @@ class MetaCollectiveVariable(openmm.CustomCVForce, CollectiveVariable):
     >>> platform = openmm.Platform.getPlatformByName('Reference')
     >>> context = openmm.Context(model.system, integrator, platform)
     >>> context.setPositions(model.positions)
+    >>> driving_force.getParameterNames()
+    ('kappa', 'phi0')
+    >>> driving_force.getParameterUnits()
+    {'kappa': kJ/(mol rad**2), 'phi0': rad}
+    >>> driving_force.getParameterValues(context)
+    {'kappa': 1000.0 kJ/(mol rad**2), 'phi0': 2.094... rad}
     >>> driving_force.getValue(context)
     548.3... kJ/mol
     >>> driving_force.getInnerValues(context)
@@ -114,10 +122,11 @@ class MetaCollectiveVariable(openmm.CustomCVForce, CollectiveVariable):
     ) -> None:
         super().__init__(function)
         self._cvs = tuple(map(copy, variables))
+        self._parameters = {k: in_md_units(v) for k, v in parameters.items()}
         for cv in self._cvs:
             self.addCollectiveVariable(cv.getName(), cv)
-        for parameter, value in parameters.items():
-            self.addGlobalParameter(parameter, value)
+        for parameter, value in self._parameters.items():
+            self.addGlobalParameter(parameter, value / value.unit)
         self._registerCV(
             name,
             unit,
@@ -125,7 +134,7 @@ class MetaCollectiveVariable(openmm.CustomCVForce, CollectiveVariable):
             variables,
             unit,
             periodicBounds,
-            **parameters,
+            **self._parameters,
         )
         if periodicBounds is not None:
             self._registerPeriodicBounds(*periodicBounds)
@@ -189,6 +198,52 @@ class MetaCollectiveVariable(openmm.CustomCVForce, CollectiveVariable):
         return {
             cv.getName(): Quantity(mass, cv.getMassUnit())
             for cv, mass in zip(self._cvs, masses)
+        }
+
+    def getParameterNames(self) -> t.Tuple[str]:
+        """
+        Get the names of the parameters of this meta-collective variable.
+
+        Returns
+        -------
+        Tuple[str]
+            A tuple with the names of the named parameters.
+        """
+        return tuple(self._parameters.keys())
+
+    def getParameterUnits(self) -> t.Dict[str, Unit]:
+        """
+        Get the units of measurement of the named parameters of this meta-collective
+        variable. The units are returned as a dictionary with the names of the
+        parameters as keys.
+
+        Returns
+        -------
+        Dict[str, Unit]
+            A dictionary with the names of the named parameters as keys and their units
+            as values.
+        """
+        return {name: parameter.unit for name, parameter in self._parameters.items()}
+
+    def getParameterValues(self, context: openmm.Context) -> t.Dict[str, Quantity]:
+        """
+        Get the values of the named parameters of this meta-collective variable. The
+        values are returned as a dictionary with the names of the parameters as keys.
+
+        Parameters
+        ----------
+        context
+            The context in which the named parameters will be evaluated.
+
+        Returns
+        -------
+        Dict[str, Quantity]
+            A dictionary with the names of the named parameters as keys and their values
+            as values.
+        """
+        return {
+            name: Quantity(context.getParameter(name), parameter.unit)
+            for name, parameter in self._parameters.items()
         }
 
 

--- a/cvpack/meta_collective_variable.py
+++ b/cvpack/meta_collective_variable.py
@@ -16,7 +16,7 @@ import openmm
 from openmm import unit as mmunit
 
 from .collective_variable import CollectiveVariable
-from .units import Quantity, ScalarQuantity, VectorQuantity, in_md_units, Unit
+from .units import Quantity, ScalarQuantity, Unit, VectorQuantity, in_md_units
 from .utils import compute_effective_mass
 
 

--- a/cvpack/tests/test_cvpack.py
+++ b/cvpack/tests/test_cvpack.py
@@ -866,7 +866,7 @@ def test_reporter():
         f"0.5*kappa*min(delta,2*pi-delta)^2" "; delta=abs(phi-5*pi/6)" f"; pi={np.pi}",
         [phi],
         unit.kilojoules_per_mole,
-        kappa=100,
+        kappa=100 * unit.kilojoules_per_mole / unit.radian**2,
         name="umbrella",
     )
     with tempfile.TemporaryDirectory() as dirpath:
@@ -884,10 +884,10 @@ def test_reporter():
                 1,
                 [umbrella],
                 [umbrella],
-                {"kappa": unit.kilojoules_per_mole / unit.radian**2},
                 step=True,
                 values=True,
                 masses=True,
+                parameters=["kappa"],
             )
             simulation.reporters.append(reporter)
             simulation.step(10)

--- a/cvpack/units/__init__.py
+++ b/cvpack/units/__init__.py
@@ -9,5 +9,6 @@ from .units import (  # noqa: F401
     ScalarQuantity,
     Unit,
     VectorQuantity,
+    in_md_units,
     value_in_md_units,
 )

--- a/cvpack/units/units.py
+++ b/cvpack/units/units.py
@@ -104,6 +104,31 @@ class Quantity(mmunit.Quantity, Serializable):
 Quantity.registerTag("!cvpack.Quantity")
 
 
+def in_md_units(
+    quantity: t.Union[ScalarQuantity, VectorQuantity, MatrixQuantity]
+) -> Quantity:
+    """
+    Return a quantity in the MD unit system (e.g. mass in Da, distance in
+    nm, time in ps, temperature in K, energy in kJ/mol, angle in rad).
+
+    Parameters
+    ----------
+    quantity
+        The quantity to be converted.
+
+    Returns
+    -------
+    Quantity
+        The quantity in the MD unit system.
+    """
+    if mmunit.is_quantity(quantity):
+        unit_in_md_system = quantity.unit.in_unit_system(mmunit.md_unit_system)
+        if 1 * quantity.unit / unit_in_md_system == 1:
+            return Quantity(quantity)
+        return Quantity(quantity.in_units_of(unit_in_md_system))
+    return quantity * Unit("dimensionless")
+
+
 def value_in_md_units(
     quantity: t.Union[ScalarQuantity, VectorQuantity, MatrixQuantity]
 ) -> t.Any:


### PR DESCRIPTION
## Description

This PR improves how named parameters are handled in meta-collective variables:

* Units of measurement are treated more explicitly
* New methods are added to inquire names and units of named parameters, as well as their current values in a context
* Reporters no longer needs parameter units as arguments