### PR TITLE
Allows attribute redirection to wrapped OpenMM forces

### DIFF
--- a/cvpack/openmm_force_wrapper.py
+++ b/cvpack/openmm_force_wrapper.py
@@ -84,10 +84,13 @@ class OpenMMForceWrapper(CollectiveVariable):
     def __getattr__(self, name: str) -> t.Any:
         attr = getattr(self._wrapped_force, name)
         if callable(attr):
+
             def _wrapped_method(*args, **kwargs):
                 return attr(*args, **kwargs)
+
             return _wrapped_method
-        else:
-            return attr
+
+        return attr
+
 
 OpenMMForceWrapper.registerTag("!cvpack.OpenMMForceWrapper")

--- a/cvpack/openmm_force_wrapper.py
+++ b/cvpack/openmm_force_wrapper.py
@@ -75,10 +75,19 @@ class OpenMMForceWrapper(CollectiveVariable):
         if isinstance(openmmForce, openmm.Force):
             openmmForce = openmm.XmlSerializer.serialize(openmmForce)
         unit = Unit(unit)
-        self.this = openmm.XmlSerializer.deserialize(openmmForce).this
+        self._wrapped_force = openmm.XmlSerializer.deserialize(openmmForce)
+        self.this = self._wrapped_force.this
         self._registerCV(name, unit, openmmForce, unit, periodicBounds)
         if periodicBounds is not None:
             self._registerPeriodicBounds(*periodicBounds)
 
+    def __getattr__(self, name: str) -> t.Any:
+        attr = getattr(self._wrapped_force, name)
+        if callable(attr):
+            def _wrapped_method(*args, **kwargs):
+                return attr(*args, **kwargs)
+            return _wrapped_method
+        else:
+            return attr
 
 OpenMMForceWrapper.registerTag("!cvpack.OpenMMForceWrapper")


### PR DESCRIPTION
## Description

This PR allows attribute access and method call redirection from a `OpenMMForceWrapper` instance to its wrapped `Force` object.