### PR TITLE
Moves path CV specification to subpackage

### DIFF
--- a/cvpack/path/__init__.py
+++ b/cvpack/path/__init__.py
@@ -1,0 +1,7 @@
+"""
+.. package:: path
+    :platform: Linux, MacOS, Windows
+    :synopsis: Specifications for Path Collective Variables
+"""
+
+from .path import Metric, deviation, progress  # noqa: F401

--- a/cvpack/path/path.py
+++ b/cvpack/path/path.py
@@ -7,7 +7,7 @@
 
 """
 
-from .serialization import Serializable
+from ..serialization import Serializable
 
 
 class Metric(Serializable):


### PR DESCRIPTION
## Description

Turns `path.py` into a subpackage.