### PR TITLE
Sets CollectiveVariable as first superclass to inherit from

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
 
 ignored-modules=openmm.unit
 ignore=_version.py
-extension-pkg-whitelist=openmm.app.internal.compiled
+extension-pkg-whitelist=openmm.app.internal.compiled,openmm._openmm
 
 [DESIGN]
 

--- a/cvpack/angle.py
+++ b/cvpack/angle.py
@@ -14,7 +14,7 @@ from openmm import unit as mmunit
 from .collective_variable import CollectiveVariable
 
 
-class Angle(openmm.CustomAngleForce, CollectiveVariable):
+class Angle(CollectiveVariable, openmm.CustomAngleForce):
     r"""
     The angle formed by three atoms:
 

--- a/cvpack/atomic_function.py
+++ b/cvpack/atomic_function.py
@@ -20,7 +20,7 @@ from .base_custom_function import BaseCustomFunction
 from .units import ScalarQuantity, VectorQuantity
 
 
-class AtomicFunction(openmm.CustomCompoundBondForce, BaseCustomFunction):
+class AtomicFunction(BaseCustomFunction, openmm.CustomCompoundBondForce):
     r"""
     A generic function of the coordinates of :math:`m` groups of :math:`n` atoms:
 

--- a/cvpack/attraction_strength.py
+++ b/cvpack/attraction_strength.py
@@ -20,7 +20,7 @@ from .utils import evaluate_in_context
 ONE_4PI_EPS0 = 138.93545764438198
 
 
-class AttractionStrength(openmm.CustomNonbondedForce, CollectiveVariable):
+class AttractionStrength(CollectiveVariable, openmm.CustomNonbondedForce):
     r"""
     The strength of the attraction between two atom groups:
 

--- a/cvpack/base_path_cv.py
+++ b/cvpack/base_path_cv.py
@@ -16,7 +16,7 @@ from .collective_variable import CollectiveVariable
 from .path import Metric, deviation, progress
 
 
-class BasePathCV(openmm.CustomCVForce, CollectiveVariable):
+class BasePathCV(CollectiveVariable, openmm.CustomCVForce):
     """
     A base class for path-related collective variables
 

--- a/cvpack/base_radius_of_gyration.py
+++ b/cvpack/base_radius_of_gyration.py
@@ -14,7 +14,7 @@ import openmm
 from .collective_variable import CollectiveVariable
 
 
-class BaseRadiusOfGyration(openmm.CustomCentroidBondForce, CollectiveVariable):
+class BaseRadiusOfGyration(CollectiveVariable, openmm.CustomCentroidBondForce):
     """
     Abstract class for the radius of gyration of a group of `n` atoms.
     """

--- a/cvpack/base_rmsd_content.py
+++ b/cvpack/base_rmsd_content.py
@@ -19,7 +19,7 @@ from .rmsd import RMSD
 from .units import ScalarQuantity, value_in_md_units
 
 
-class BaseRMSDContent(openmm.CustomCVForce, CollectiveVariable):
+class BaseRMSDContent(CollectiveVariable, openmm.CustomCVForce):
     """
     Abstract class for secondary-structure RMSD content of a sequence of `n` residues.
     """

--- a/cvpack/centroid_function.py
+++ b/cvpack/centroid_function.py
@@ -18,7 +18,7 @@ from .base_custom_function import BaseCustomFunction
 from .units import ScalarQuantity, VectorQuantity
 
 
-class CentroidFunction(openmm.CustomCentroidBondForce, BaseCustomFunction):
+class CentroidFunction(BaseCustomFunction, openmm.CustomCentroidBondForce):
     r"""
     A generic function of the centroids of :math:`m \times n` atoms groups split
     into `m` collections of `n` groups:

--- a/cvpack/collective_variable.py
+++ b/cvpack/collective_variable.py
@@ -11,6 +11,7 @@ import typing as t
 
 import openmm
 import yaml
+from openmm import _openmm as mmswig
 from openmm import unit as mmunit
 
 from .serialization import Serializable
@@ -18,7 +19,7 @@ from .units import Quantity, ScalarQuantity, Unit
 from .utils import compute_effective_mass, get_single_force_state, preprocess_args
 
 
-class CollectiveVariable(openmm.Force, Serializable):
+class CollectiveVariable(Serializable):
     r"""
     An abstract class with common attributes and method for all CVs.
     """
@@ -63,7 +64,7 @@ class CollectiveVariable(openmm.Force, Serializable):
         kwargs
             The keyword arguments needed to construct this collective variable
         """
-        self.setName(name)
+        mmswig.Force_setName(self, name)
         self._unit = cvUnit
         self._mass_unit = Unit(mmunit.dalton * (mmunit.nanometers / self._unit) ** 2)
         self._args = {"name": name}
@@ -116,13 +117,13 @@ class CollectiveVariable(openmm.Force, Serializable):
         new_group = next(filter(lambda i: i not in used_groups, range(32)), None)
         if new_group is None:
             raise RuntimeError("All force groups are already in use.")
-        self.setForceGroup(new_group)
+        mmswig.Force_setForceGroup(self, new_group)
 
     def getName(self) -> str:  # pylint: disable=useless-parent-delegation
         """
         Get the name of this collective variable.
         """
-        return super().getName()
+        return mmswig.Force_getName(self)
 
     def getUnit(self) -> Unit:
         """

--- a/cvpack/composite_rmsd.py
+++ b/cvpack/composite_rmsd.py
@@ -28,7 +28,7 @@ except ImportError:
     CompositeRMSDForce = _Stub
 
 
-class CompositeRMSD(CompositeRMSDForce, BaseRMSD):
+class CompositeRMSD(BaseRMSD, CompositeRMSDForce):
     r"""
     The composite root-mean-square deviation (RMSD) between the current and reference
     coordinates of :math:`m` groups of atoms:

--- a/cvpack/distance.py
+++ b/cvpack/distance.py
@@ -13,7 +13,7 @@ from openmm import unit as mmunit
 from .collective_variable import CollectiveVariable
 
 
-class Distance(openmm.CustomBondForce, CollectiveVariable):
+class Distance(CollectiveVariable, openmm.CustomBondForce):
     r"""
     The distance between two atoms:
 

--- a/cvpack/helix_angle_content.py
+++ b/cvpack/helix_angle_content.py
@@ -17,7 +17,7 @@ from .collective_variable import CollectiveVariable
 from .units import Quantity, ScalarQuantity
 
 
-class HelixAngleContent(openmm.CustomAngleForce, CollectiveVariable):
+class HelixAngleContent(CollectiveVariable, openmm.CustomAngleForce):
     r"""
     The alpha-helix angle content of a sequence of `n` residues:
 

--- a/cvpack/helix_hbond_content.py
+++ b/cvpack/helix_hbond_content.py
@@ -18,7 +18,7 @@ from .collective_variable import CollectiveVariable
 from .units import Quantity, ScalarQuantity
 
 
-class HelixHBondContent(openmm.CustomBondForce, CollectiveVariable):
+class HelixHBondContent(CollectiveVariable, openmm.CustomBondForce):
     r"""
     The alpha-helix hydrogen-bond content of a sequence of `n` residues:
 

--- a/cvpack/helix_torsion_content.py
+++ b/cvpack/helix_torsion_content.py
@@ -17,7 +17,7 @@ from .collective_variable import CollectiveVariable
 from .units import Quantity, ScalarQuantity
 
 
-class HelixTorsionContent(openmm.CustomTorsionForce, CollectiveVariable):
+class HelixTorsionContent(CollectiveVariable, openmm.CustomTorsionForce):
     r"""
     The alpha-helix Ramachandran content of a sequence of `n` residues:
 

--- a/cvpack/meta_collective_variable.py
+++ b/cvpack/meta_collective_variable.py
@@ -20,7 +20,7 @@ from .units import Quantity, ScalarQuantity, VectorQuantity, in_md_units
 from .utils import compute_effective_mass, get_single_force_state
 
 
-class MetaCollectiveVariable(openmm.CustomCVForce, CollectiveVariable):
+class MetaCollectiveVariable(CollectiveVariable, openmm.CustomCVForce):
     r"""
     A collective variable that is a function of other collective variables:
 

--- a/cvpack/number_of_contacts.py
+++ b/cvpack/number_of_contacts.py
@@ -18,7 +18,7 @@ from .units import Quantity, ScalarQuantity
 from .utils import evaluate_in_context
 
 
-class NumberOfContacts(openmm.CustomNonbondedForce, CollectiveVariable):
+class NumberOfContacts(CollectiveVariable, openmm.CustomNonbondedForce):
     r"""
     The number of contacts between two atom groups:
 

--- a/cvpack/openmm_force_wrapper.py
+++ b/cvpack/openmm_force_wrapper.py
@@ -16,7 +16,7 @@ from .collective_variable import CollectiveVariable
 from .units import Unit, VectorQuantity
 
 
-class OpenMMForceWrapper(CollectiveVariable):
+class OpenMMForceWrapper(CollectiveVariable, openmm.Force):
     r"""
     A collective variable whose numerical value is computed from the potential energy,
     in kJ/mol, of an OpenMM force object.

--- a/cvpack/residue_coordination.py
+++ b/cvpack/residue_coordination.py
@@ -18,7 +18,7 @@ from .collective_variable import CollectiveVariable
 from .units import Quantity, ScalarQuantity, value_in_md_units
 
 
-class ResidueCoordination(openmm.CustomCentroidBondForce, CollectiveVariable):
+class ResidueCoordination(CollectiveVariable, openmm.CustomCentroidBondForce):
     r"""
     The number of contacts between two disjoint groups of residues:
 

--- a/cvpack/rmsd.py
+++ b/cvpack/rmsd.py
@@ -16,7 +16,7 @@ from .base_rmsd import BaseRMSD
 from .units import MatrixQuantity, VectorQuantity
 
 
-class RMSD(openmm.RMSDForce, BaseRMSD):
+class RMSD(BaseRMSD, openmm.RMSDForce):
     r"""
     The root-mean-square deviation (RMSD) between the current and reference
     coordinates of a group of `n` atoms:

--- a/cvpack/shortest_distance.py
+++ b/cvpack/shortest_distance.py
@@ -16,7 +16,7 @@ from .collective_variable import CollectiveVariable
 from .units import Quantity
 
 
-class ShortestDistance(openmm.CustomCVForce, CollectiveVariable):
+class ShortestDistance(CollectiveVariable, openmm.CustomCVForce):
     r"""
     A smooth approximation of the shortest distance between two atom groups:
 

--- a/cvpack/torsion.py
+++ b/cvpack/torsion.py
@@ -14,7 +14,7 @@ from openmm import unit as mmunit
 from .collective_variable import CollectiveVariable
 
 
-class Torsion(openmm.CustomTorsionForce, CollectiveVariable):
+class Torsion(CollectiveVariable, openmm.CustomTorsionForce):
     r"""
     The torsion angle formed by four atoms:
 

--- a/cvpack/torsion_similarity.py
+++ b/cvpack/torsion_similarity.py
@@ -15,7 +15,7 @@ from openmm import unit as mmunit
 from .collective_variable import CollectiveVariable
 
 
-class TorsionSimilarity(openmm.CustomCompoundBondForce, CollectiveVariable):
+class TorsionSimilarity(CollectiveVariable, openmm.CustomCompoundBondForce):
     r"""
     The degree of similarity between `n` pairs of torsion angles:
 


### PR DESCRIPTION
## Description

This PR solves an MRO issue with the __copy__ method by making `CollectiveVariable.__copy__` as the higest-priority one.